### PR TITLE
feat: new modifiers (Knockback, ArmorCharge, FireTrail) + immunity rework to configurable resistance

### DIFF
--- a/MonsterModifiers/MonsterModifiers.csproj
+++ b/MonsterModifiers/MonsterModifiers.csproj
@@ -63,6 +63,14 @@
     </When>
   </Choose>
   <ItemGroup>
+    <Reference Include="Jotunn">
+      <HintPath>$(NuGetPackageRoot)jotunnlib\2.26.0\lib\net462\Jotunn.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="YamlDotNet">
+      <HintPath>$(NuGetPackageRoot)yamldotnet\16.3.0\lib\net47\YamlDotNet.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="0Harmony">
       <HintPath>$(BepInExPath)\core\0Harmony.dll</HintPath>
     </Reference>
@@ -132,6 +140,10 @@
     <Compile Include="Src\Modifiers\FoodDrain.cs" />
     <Compile Include="Src\Modifiers\ElementalInfusions.cs" />
     <Compile Include="Src\Modifiers\Forceful.cs" />
+    <Compile Include="Src\Modifiers\Knockback.cs" />
+    <Compile Include="Src\Modifiers\ResistanceNotification.cs" />
+    <Compile Include="Src\Modifiers\FireTrail.cs" />
+    <Compile Include="Src\Modifiers\ArmorCharge.cs" />
     <Compile Include="Src\Modifiers\IgnoreArmor.cs" />
     <Compile Include="Src\Modifiers\Quiet.cs" />
     <Compile Include="Src\Modifiers\StaggerDeath.cs" />
@@ -149,6 +161,7 @@
     <Compile Include="Src\Patches\AddMonsterModifiersToCharacter.cs" />
     <Compile Include="Src\Patches\AddVisualsPatch.cs" />
     <Compile Include="Src\Patches\EnemyHudPatch.cs" />
+    <Compile Include="Src\Patches\ShaderLogFilter.cs" />
     <Compile Include="Src\Plugin.cs" />
     <Compile Include="Src\StatusEffects\BloodLoss_SE.cs" />
     <Compile Include="Src\StatusEffects\HealDeath_SE.cs" />

--- a/MonsterModifiers/README.md
+++ b/MonsterModifiers/README.md
@@ -1,22 +1,127 @@
-# All In One -  Manager Template.
+# Captain Monster Modifiers
 
-Please see the individual templates for more information on how to use each one. This template is only to set up the project for you. All code provided in this template is example code and might not be needed for your specific use case.
+발헤임(Valheim)의 몬스터에 다양한 랜덤 속성을 부여하는 BepInEx 모드입니다.
 
+## 원작자 (Original Author)
 
-## Template Links
-- [ItemManager Mod Template](https://github.com/AzumattDev/ItemManagerModTemplate)
-- [CreatureManager Mod Template](https://github.com/AzumattDev/CreatureManagerModTemplate)
-- [SkillManager Mod Template](https://github.com/AzumattDev/SkillManagerModTemplate)
-- [PieceManager Mod Template](https://github.com/AzumattDev/PieceManagerModTemplate)
-- [LocationManager Mod Template](https://github.com/AzumattDev/LocationManagerModTemplate)
-- [StatusEffectManager Mod Template](https://github.com/AzumattDev/StatusEffectManagerModTemplate)
+**warpalicious** — 원본 MonsterModifiers 모드 제작자  
+본 모드는 warpalicious의 원작을 기반으로 KorCaptain이 확장 수정한 버전입니다.
 
-## Original Repos from Blaxxun
-- [ItemManager](https://github.com/blaxxun-boop/ItemManager)
-- [CreatureManager](https://github.com/blaxxun-boop/CreatureManager)
-- [SkillManager](https://github.com/blaxxun-boop/SkillManager)
-- [LocationManager](https://github.com/blaxxun-boop/LocationManager)
+---
 
-## Original Repos from Me
-- [PieceManager](https://github.com/AzumattDev/PieceManager)
-- [StatusEffectManager](https://github.com/AzumattDev/StatusEffectManager)
+## 주요 기능
+
+### 몬스터 속성 시스템
+
+레벨 2 이상 몬스터는 최대 N개(설정 가능)의 랜덤 속성을 보유합니다.  
+속성은 몬스터 HP 바 위의 아이콘으로 표시됩니다.
+
+### 저항 속성 (방어 계열)
+
+| 속성 | 효과 |
+|------|------|
+| **PierceImmunity** | 관통 데미지 -70% 저항 |
+| **SlashImmunity** | 베기 데미지 -70% 저항 |
+| **BluntImmunity** | 둔기 데미지 -70% 저항 |
+| **ElementalImmunity** | 화염/냉기/번개/독/영혼 데미지 -70% 저항 |
+| **StaggerImmune** | 경직(스태거) 면역 |
+| **PersonalShield** | 개인 방어막 |
+| **ShieldDome** | 방어 돔 생성 |
+
+### 공격 속성 (공격 계열)
+
+| 속성 | 효과 |
+|------|------|
+| **StaminaSiphon** | 플레이어 스태미나 흡수 |
+| **EitrSiphon** | 플레이어 에이트르 흡수 |
+| **FoodDrain** | 플레이어 음식 고갈 |
+| **IgnoreArmor** | 방어력 무시 |
+| **ShieldBreaker** | 방패 파괴 |
+| **Forceful** | 강력한 넉백 (5배) |
+| **Knockback** | 7미터 넉백 공격 |
+| **FastAttackSpeed** | 빠른 공격 속도 |
+| **FireInfused / FrostInfused / PoisonInfused / LightningInfused** | 원소 속성 공격 추가 |
+| **Vampiric** | 공격 시 체력 흡수 |
+| **Absorption** | 저항 속성 피해를 체력으로 흡수 |
+| **BloodLoss** | 출혈 상태효과 |
+| **Wet** | 젖음 상태효과 |
+
+### 이동/감지 속성
+
+| 속성 | 효과 |
+|------|------|
+| **FastMovement** | 이동 속도 증가 |
+| **DistantDetection** | 원거리 감지 |
+| **Quiet** | 소음 제거 (은신 특화) |
+
+### 사망 속성 (Death Effects)
+
+| 속성 | 효과 |
+|------|------|
+| **FireDeath / FrostDeath / PoisonDeath** | 사망 시 해당 원소 폭발 |
+| **HealDeath** | 사망 시 주변 몬스터 치유 |
+| **StaggerDeath** | 사망 시 주변 경직 |
+| **TarDeath** | 사망 시 타르 투척 |
+
+### 특수 속성
+
+| 속성 | 효과 |
+|------|------|
+| **SoulEater** | 영혼 흡수 |
+| **RemoveStatusEffect** | 플레이어 상태효과 제거 |
+
+---
+
+## 설정 (Config)
+
+설정 파일: `BepInEx/config/KorCaptain.Captain_Monster_modifiers.cfg`
+
+### Balance 섹션
+
+| 항목 | 기본값 | 설명 |
+|------|--------|------|
+| Max Modifiers | 5 | 몬스터 1마리당 최대 속성 수 |
+
+### Monster_Base 섹션
+
+| 항목 | 기본값 | 설명 |
+|------|--------|------|
+| Monster Attack 효과 % | 100 | 공격 속성 전체 성능 조절 (0=효과 없음) |
+| Monster Defense & Etc 효과 % | 100 | 방어/저항 속성 전체 성능 조절 (0=저항 없음) |
+
+> **예시**: `Monster Defense & Etc 효과 % = 0` 설정 시 PierceImmunity 몬스터가 관통 데미지를 100% 받음
+
+---
+
+## 서버 동기화
+
+서버와 클라이언트 모두 동일한 버전이 설치되어야 합니다.  
+버전 불일치 시 접속이 차단됩니다.  
+설정값은 서버 설정이 클라이언트에 자동 동기화됩니다.
+
+---
+
+## 설치
+
+1. BepInEx가 설치된 발헤임 디렉토리에 `CaptainMonsterModifiers.dll`을 `BepInEx/plugins/` 폴더에 복사
+2. Jotunn 라이브러리 필요
+
+---
+
+## 버전 히스토리
+
+### v1.3.0 (KorCaptain 수정판)
+- 면역(Immune) → -70% 저항으로 변경 (관통/베기/둔기/원소)
+- Monster_Base Config 추가: Attack 효과 %, Defense & Etc 효과 %
+- 새 속성 추가: Knockback (7미터 넉백)
+- 서버 싱크 Config 동기화
+
+### v1.2.6 (warpalicious 원작)
+- 원작 최종 버전
+
+---
+
+## 크레딧
+
+- **원작자**: warpalicious (원본 MonsterModifiers)
+- **수정/확장**: KorCaptain

--- a/MonsterModifiers/Src/Config/modifierValues.yml
+++ b/MonsterModifiers/Src/Config/modifierValues.yml
@@ -129,3 +129,11 @@ Wet:
 Quiet:
   weight: 0
   color: [0.88, 0.01, 0.15, 1]  # Red
+
+Knockback:
+  weight: 1
+  color: [0.95, 0.60, 0.10, 1]  # Orange
+
+SummonDeath:
+  weight: 1
+  color: [0.85, 0.85, 0.85, 1]  # Light Gray (bone)

--- a/MonsterModifiers/Src/Custom Components/MonsterModifier.cs
+++ b/MonsterModifiers/Src/Custom Components/MonsterModifier.cs
@@ -34,7 +34,7 @@ public class MonsterModifier : MonoBehaviour
          string modifiersString = character.m_nview.GetZDO().GetString("modifiers", string.Empty);
          if (string.IsNullOrEmpty(modifiersString))
          {
-            int numModifiers = Mathf.Min(level - 1, MonsterModifiersPlugin.Configurations_MaxModifiers.Value);
+            int numModifiers = Mathf.Min(level, MonsterModifiersPlugin.Configurations_MaxModifiers.Value);
             
             foreach (var modifier in ModifierUtils.RollRandomModifiers(numModifiers))
             {
@@ -51,8 +51,11 @@ public class MonsterModifier : MonoBehaviour
          }
          else
          {
-            Modifiers = new List<MonsterModifierTypes>(Array.ConvertAll(modifiersString.Split(','), 
-               str => (MonsterModifierTypes)Enum.Parse(typeof(MonsterModifierTypes), str)));
+            foreach (string str in modifiersString.Split(','))
+            {
+               if (Enum.TryParse(str.Trim(), out MonsterModifierTypes parsed))
+                  Modifiers.Add(parsed);
+            }
          }
 
          ApplyStartModifiers();
@@ -108,6 +111,19 @@ public class MonsterModifier : MonoBehaviour
       if (Modifiers.Contains(MonsterModifierTypes.Quiet))
       {
          Quiet.AddQuiet(character);
+      }
+
+      // 시너지: FireInfused + FastAttackSpeed → 화염 흔적
+      if (Modifiers.Contains(MonsterModifierTypes.FireInfused) && Modifiers.Contains(MonsterModifierTypes.FastAttackSpeed))
+      {
+         var fireTrail = character.gameObject.AddComponent<Modifiers.FireTrail>();
+         fireTrail.Initialize(character);
+      }
+
+      // 시너지: 물리 3종 저항 + FastMovement → 철갑 돌격
+      if (ArmorCharge.IsArmorChargeType(this))
+      {
+         ArmorCharge.ApplyArmorCharge(character);
       }
    }
 }

--- a/MonsterModifiers/Src/Modifiers/Absorption.cs
+++ b/MonsterModifiers/Src/Modifiers/Absorption.cs
@@ -5,72 +5,43 @@ namespace MonsterModifiers.Modifiers;
 
 public class Absorption
 {
+    [HarmonyPriority(Priority.High)]
     [HarmonyPatch(typeof(Character), nameof(Character.RPC_Damage))]
     public class Absorption_Character_RPC_Damage_Patch
     {
         public static void Prefix(Character __instance, HitData hit)
         {
             if (hit == null || __instance == null)
-            {
                 return;
-            }
-            
+
             var modiferComponent = __instance.GetComponent<Custom_Components.MonsterModifier>();
             if (modiferComponent == null)
-            {
                 return;
-            }
 
             if (!modiferComponent.Modifiers.Contains(MonsterModifierTypes.Absorption))
-            {
                 return;
-            }
-            
+
             if (hit.m_damage.GetTotalDamage() == 0)
-            {
                 return;
-            }
 
-            HitData.DamageModifiers monsterDamageModifiers = __instance.GetDamageModifiers();
-            
-            HealIfImmune(__instance, monsterDamageModifiers, HitData.DamageType.Blunt, hit.m_damage.m_blunt);
-            HealIfImmune(__instance, monsterDamageModifiers, HitData.DamageType.Slash, hit.m_damage.m_slash);
-            HealIfImmune(__instance, monsterDamageModifiers, HitData.DamageType.Pierce, hit.m_damage.m_pierce);
-            HealIfImmune(__instance, monsterDamageModifiers, HitData.DamageType.Chop, hit.m_damage.m_chop);
-            HealIfImmune(__instance, monsterDamageModifiers, HitData.DamageType.Pickaxe, hit.m_damage.m_pickaxe);
-            HealIfImmune(__instance, monsterDamageModifiers, HitData.DamageType.Fire, hit.m_damage.m_fire);
-            HealIfImmune(__instance, monsterDamageModifiers, HitData.DamageType.Frost, hit.m_damage.m_frost);
-            HealIfImmune(__instance, monsterDamageModifiers, HitData.DamageType.Lightning, hit.m_damage.m_lightning);
-            HealIfImmune(__instance, monsterDamageModifiers, HitData.DamageType.Poison, hit.m_damage.m_poison);
-            HealIfImmune(__instance, monsterDamageModifiers, HitData.DamageType.Spirit, hit.m_damage.m_spirit);
-        }
+            float healRatio = MonsterModifiersPlugin.Cfg_Absorption_HealPercent.Value / 100f;
 
-        public static void HealIfImmune(Character character, HitData.DamageModifiers modifiers, HitData.DamageType type, float damage)
-        {
-            if (damage > 0 && IsDamageTypeImmune(modifiers, type))
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.BluntImmunity) && hit.m_damage.m_blunt > 0)
+                __instance.Heal(hit.m_damage.m_blunt * healRatio);
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.SlashImmunity) && hit.m_damage.m_slash > 0)
+                __instance.Heal(hit.m_damage.m_slash * healRatio);
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.PierceImmunity) && hit.m_damage.m_pierce > 0)
+                __instance.Heal(hit.m_damage.m_pierce * healRatio);
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.ElementalImmunity))
             {
-                // Debug.Log("Monster is immune to damage of type: " + type + "healing monster for amount: " + damage);
-                character.Heal(damage);
+                float elementalHeal = (hit.m_damage.m_fire + hit.m_damage.m_frost + hit.m_damage.m_lightning
+                    + hit.m_damage.m_poison + hit.m_damage.m_spirit) * healRatio;
+                if (elementalHeal > 0)
+                    __instance.Heal(elementalHeal);
             }
-        }
-
-        public static bool IsDamageTypeImmune(HitData.DamageModifiers modifiers, HitData.DamageType type)
-        {
-            return type switch
-            {
-                HitData.DamageType.Blunt => modifiers.m_blunt == HitData.DamageModifier.Immune,
-                HitData.DamageType.Slash => modifiers.m_slash == HitData.DamageModifier.Immune,
-                HitData.DamageType.Pierce => modifiers.m_pierce == HitData.DamageModifier.Immune,
-                HitData.DamageType.Chop => modifiers.m_chop == HitData.DamageModifier.Immune,
-                HitData.DamageType.Pickaxe => modifiers.m_pickaxe == HitData.DamageModifier.Immune,
-                HitData.DamageType.Fire => modifiers.m_fire == HitData.DamageModifier.Immune,
-                HitData.DamageType.Frost => modifiers.m_frost == HitData.DamageModifier.Immune,
-                HitData.DamageType.Lightning => modifiers.m_lightning == HitData.DamageModifier.Immune,
-                HitData.DamageType.Poison => modifiers.m_poison == HitData.DamageModifier.Immune,
-                HitData.DamageType.Spirit => modifiers.m_spirit == HitData.DamageModifier.Immune,
-                _ => false,
-            };
         }
     }
-    
 }

--- a/MonsterModifiers/Src/Modifiers/ArmorCharge.cs
+++ b/MonsterModifiers/Src/Modifiers/ArmorCharge.cs
@@ -1,0 +1,56 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+// 시너지: 관통+베기+둔기 저항 3종 + FastMovement = "철갑 돌격" 타입
+// 효과: 이동속도 추가 +30%, 공격 시 데미지 +50%
+public class ArmorCharge
+{
+    private const float ExtraSpeedMult = 1.3f;
+    private const float ExtraDamageMult = 1.5f;
+
+    public static bool IsArmorChargeType(Custom_Components.MonsterModifier modifier)
+    {
+        return modifier.Modifiers.Contains(MonsterModifierTypes.PierceImmunity)
+            && modifier.Modifiers.Contains(MonsterModifierTypes.SlashImmunity)
+            && modifier.Modifiers.Contains(MonsterModifierTypes.BluntImmunity)
+            && modifier.Modifiers.Contains(MonsterModifierTypes.FastMovement);
+    }
+
+    public static void ApplyArmorCharge(Character character)
+    {
+        character.m_speed *= ExtraSpeedMult;
+        character.m_runSpeed *= ExtraSpeedMult;
+        character.m_walkSpeed *= ExtraSpeedMult;
+    }
+
+    // 철갑 돌격 타입 몬스터의 공격 데미지 +50%
+    [HarmonyPatch(typeof(Character), nameof(Character.RPC_Damage))]
+    public class ArmorCharge_Character_RPC_Damage_Patch
+    {
+        public static void Prefix(Character __instance, HitData hit)
+        {
+            if (!ModifierUtils.RunRPCDamageChecks(__instance, hit))
+                return;
+
+            if (!ModifierUtils.RunHitChecks(hit, true))
+                return;
+
+            var attacker = hit.GetAttacker();
+            var modiferComponent = attacker?.GetComponent<Custom_Components.MonsterModifier>();
+            if (modiferComponent == null)
+                return;
+
+            if (!IsArmorChargeType(modiferComponent))
+                return;
+
+            hit.m_damage.m_blunt *= ExtraDamageMult;
+            hit.m_damage.m_slash *= ExtraDamageMult;
+            hit.m_damage.m_pierce *= ExtraDamageMult;
+            hit.m_damage.m_fire *= ExtraDamageMult;
+            hit.m_damage.m_frost *= ExtraDamageMult;
+            hit.m_damage.m_lightning *= ExtraDamageMult;
+        }
+    }
+}

--- a/MonsterModifiers/Src/Modifiers/DamageModifiers.cs
+++ b/MonsterModifiers/Src/Modifiers/DamageModifiers.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using HarmonyLib;
 using UnityEngine;
 
@@ -13,43 +11,36 @@ public class DamageModifiers
         public static void Prefix(Character __instance, HitData hit)
         {
             if (hit == null || __instance == null)
-            {
                 return;
-            }
-            
+
             if (hit.m_damage.GetTotalDamage() == 0)
-            {
                 return;
-            }
-            
+
+            // 몬스터만 적용 (플레이어 제외)
+            if (__instance.IsPlayer())
+                return;
+
             var modiferComponent = __instance.GetComponent<Custom_Components.MonsterModifier>();
             if (modiferComponent == null)
-            {
                 return;
-            }
 
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.PierceImmunity))
-            {
-                __instance.m_damageModifiers.m_pierce = HitData.DamageModifier.Immune;
-            }
-            
+                hit.m_damage.m_pierce *= (1f - MonsterModifiersPlugin.Cfg_PierceImmunity_DamageReduction.Value / 100f);
+
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.SlashImmunity))
-            {
-                __instance.m_damageModifiers.m_slash = HitData.DamageModifier.Immune;
-            }
-            
+                hit.m_damage.m_slash *= (1f - MonsterModifiersPlugin.Cfg_SlashImmunity_DamageReduction.Value / 100f);
+
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.BluntImmunity))
-            {
-                __instance.m_damageModifiers.m_blunt = HitData.DamageModifier.Immune;
-            }
-            
+                hit.m_damage.m_blunt *= (1f - MonsterModifiersPlugin.Cfg_BluntImmunity_DamageReduction.Value / 100f);
+
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.ElementalImmunity))
             {
-                __instance.m_damageModifiers.m_fire = HitData.DamageModifier.Immune;
-                __instance.m_damageModifiers.m_frost = HitData.DamageModifier.Immune;
-                __instance.m_damageModifiers.m_lightning = HitData.DamageModifier.Immune;
-                __instance.m_damageModifiers.m_poison = HitData.DamageModifier.Immune;
-                __instance.m_damageModifiers.m_spirit = HitData.DamageModifier.Immune;
+                float elemMult = 1f - MonsterModifiersPlugin.Cfg_ElementalImmunity_DamageReduction.Value / 100f;
+                hit.m_damage.m_fire *= elemMult;
+                hit.m_damage.m_frost *= elemMult;
+                hit.m_damage.m_lightning *= elemMult;
+                hit.m_damage.m_poison *= elemMult;
+                hit.m_damage.m_spirit *= elemMult;
             }
         }
     }

--- a/MonsterModifiers/Src/Modifiers/DeathSpawns.cs
+++ b/MonsterModifiers/Src/Modifiers/DeathSpawns.cs
@@ -39,7 +39,7 @@ public class DeathSpawns
 
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.PoisonDeath))
             {
-                float deathSpawnDamage = DamageUtils.CalculateDamage(__instance, 0.5f);
+                float deathSpawnDamage = DamageUtils.CalculateDamage(__instance, MonsterModifiersPlugin.Cfg_PoisonDeath_DamagePercent.Value / 100f);
                 GameObject blobAoe = ZNetScene.instance.GetPrefab("blob_aoe");
                 if (blobAoe != null)
                 {
@@ -56,7 +56,7 @@ public class DeathSpawns
                 
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.FireDeath))
             {
-                float deathSpawnDamage = DamageUtils.CalculateDamage(__instance, 0.5f);
+                float deathSpawnDamage = DamageUtils.CalculateDamage(__instance, MonsterModifiersPlugin.Cfg_FireDeath_DamagePercent.Value / 100f);
                 // TO-DO: I'm overwriting the vanilla values here. Make a copy somehow.
                 GameObject fireNovaAOE = ZNetScene.instance.GetPrefab("fx_fireskeleton_nova");
 
@@ -90,7 +90,7 @@ public class DeathSpawns
             
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.FrostDeath))
             {
-                float deathSpawnDamage = DamageUtils.CalculateDamage(__instance, 0.5f);
+                float deathSpawnDamage = DamageUtils.CalculateDamage(__instance, MonsterModifiersPlugin.Cfg_FrostDeath_DamagePercent.Value / 100f);
                 GameObject frostNovaAOE = ZNetScene.instance.GetPrefab("fx_DvergerMage_Nova_ring");
                 // TimedDestruction timedDestruction = frostNovaAOE.GetComponent<TimedDestruction>();
                 // timedDestruction.m_timeout = 2.5f;
@@ -146,7 +146,7 @@ public class DeathSpawns
             {
                 GameObject healNova = PrefabManager.Instance.GetPrefab("healCustomPrefab");
                 
-                float healAmount = (__instance.GetMaxHealth() * 0.75f);
+                float healAmount = __instance.GetMaxHealth() * (MonsterModifiersPlugin.Cfg_HealDeath_HealPercent.Value / 100f);
                 
                 if (healNova != null)
                 {
@@ -169,11 +169,11 @@ public class DeathSpawns
                             continue;
                         }
                         
-                        if (character.m_nview == null || character.IsPlayer())
+                        if (character.m_nview == null || character.m_nview.GetZDO() == null || character.IsPlayer())
                         {
                             continue;
                         }
-                        
+
                         character.GetSEMan().AddStatusEffect("HealDeathStatusEffect".GetStableHashCode(),false,0,healAmount);
                         // Debug.Log("Character with name: " + character.name + " was given HealDeath status effect");
                     }
@@ -182,11 +182,11 @@ public class DeathSpawns
                     Player.GetPlayersInRange(__instance.transform.position, 15f, nearbyPlayers);
                     foreach (Character character in nearbyPlayers)
                     {
-                        if (character == null || character.m_nview == null)
+                        if (character == null || character.m_nview == null || character.m_nview.GetZDO() == null)
                         {
                             continue;
                         }
-                        
+
                         character.GetSEMan().AddStatusEffect("HealDeathStatusEffect".GetStableHashCode(),true,0,healAmount);
                         // Debug.Log("Player with name: " + character.name + " was given HealDeath status effect");
                     }
@@ -196,7 +196,7 @@ public class DeathSpawns
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.TarDeath))
             {
                 GameObject tarNova = ZNetScene.instance.GetPrefab("blobtar_projectile_tarball");
-                
+
                 if (tarNova != null)
                 {
                     GameObject.Instantiate(tarNova,
@@ -217,15 +217,15 @@ public class DeathSpawns
                         {
                             continue;
                         }
-                        
+
                         if (character.m_nview == null || character.IsPlayer())
                         {
                             continue;
                         }
-                        
+
                         character.GetSEMan().AddStatusEffect("Tared".GetStableHashCode());
                     }
-            
+
                     List<Player> nearbyPlayers = new List<Player>();
                     Player.GetPlayersInRange(__instance.transform.position, 5f, nearbyPlayers);
                     foreach (Character character in nearbyPlayers)
@@ -234,8 +234,58 @@ public class DeathSpawns
                         {
                             continue;
                         }
-                        
+
                         character.GetSEMan().AddStatusEffect("Tared".GetStableHashCode());
+                    }
+                }
+            }
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.SummonDeath))
+            {
+                if (__instance.m_nview != null && __instance.m_nview.IsOwner())
+                {
+                    string prefabName = Utils.GetPrefabName(__instance.gameObject);
+                    GameObject summonPrefab = ZNetScene.instance.GetPrefab(prefabName);
+                    if (summonPrefab == null) return;
+
+                    int spawnCount = Mathf.Min(modiferComponent.Modifiers.Count + 1, 5);
+                    float parentHealth = __instance.GetMaxHealth();
+                    // 부모 속성 수 - 1 = 자식 속성 수. 0이 되면 SummonDeath 불가 → 자연 종료
+                    int childModCount = Mathf.Max(modiferComponent.Modifiers.Count - 1, 0);
+
+                    for (int i = 0; i < spawnCount; i++)
+                    {
+                        // 자식마다 개별 랜덤 롤
+                        List<MonsterModifierTypes> childMods = childModCount > 0
+                            ? ModifierUtils.RollRandomModifiers(childModCount)
+                            : new List<MonsterModifierTypes>();
+
+                        Vector3 offset = new Vector3(
+                            UnityEngine.Random.Range(-2f, 2f),
+                            0f,
+                            UnityEngine.Random.Range(-2f, 2f)
+                        );
+                        GameObject spawned = Object.Instantiate(summonPrefab,
+                            __instance.transform.position + offset,
+                            Quaternion.identity);
+
+                        spawned.transform.localScale *= MonsterModifiersPlugin.Cfg_SummonDeath_ScalePercent.Value / 100f;
+
+                        Character spawnedChar = spawned.GetComponent<Character>();
+                        if (spawnedChar == null) continue;
+
+                        int spawnLevel = childMods.Count > 0 ? childMods.Count + 1 : 1;
+                        spawnedChar.SetLevel(spawnLevel);
+
+                        ZDO zdo = spawnedChar.m_nview?.GetZDO();
+                        if (zdo != null && zdo.IsOwner())
+                        {
+                            if (childMods.Count > 0)
+                                zdo.Set("modifiers", string.Join(",", childMods));
+                            float healthPct = MonsterModifiersPlugin.Cfg_SummonDeath_HealthPercent.Value / 100f;
+                            spawnedChar.SetMaxHealth(parentHealth * healthPct);
+                            spawnedChar.SetHealth(parentHealth * healthPct);
+                        }
                     }
                 }
             }

--- a/MonsterModifiers/Src/Modifiers/DistantDetection.cs
+++ b/MonsterModifiers/Src/Modifiers/DistantDetection.cs
@@ -6,23 +6,23 @@ public class DistantDetection
 {
     public static void AddDistantDetection(Character character)
     {
-        // Debug.Log("Monster with name " + character.m_name + " has modifier Stagger Immune");
         BaseAI baseAI = character.m_baseAI;
         if (baseAI != null)
         {
-            baseAI.m_hearRange *= 2.0f;
-            baseAI.m_viewRange *= 2.0f;
+            float rangeMult = MonsterModifiersPlugin.Cfg_DistantDetection_RangeMultiplier.Value;
+            baseAI.m_hearRange *= rangeMult;
+            baseAI.m_viewRange *= rangeMult;
         }
     }
-    
+
     public static void RemoveDistantDetection(Character character)
     {
-        // Debug.Log("Monster with name " + character.m_name + " has modifier Stagger Immune");
         BaseAI baseAI = character.m_baseAI;
         if (baseAI != null)
         {
-            baseAI.m_hearRange /= 2.0f;
-            baseAI.m_viewRange /= 2.0f;
+            float rangeMult = MonsterModifiersPlugin.Cfg_DistantDetection_RangeMultiplier.Value;
+            baseAI.m_hearRange /= rangeMult;
+            baseAI.m_viewRange /= rangeMult;
         }
     }
 }

--- a/MonsterModifiers/Src/Modifiers/EitrSiphon.cs
+++ b/MonsterModifiers/Src/Modifiers/EitrSiphon.cs
@@ -38,7 +38,7 @@ public class EitrSiphon
                 return;
             }
             
-            __instance.UseEitr(hit.GetTotalDamage());
+            __instance.UseEitr(hit.GetTotalDamage() * (MonsterModifiersPlugin.Cfg_EitrSiphon_DrainPercent.Value / 100f));
         }
     }
 }

--- a/MonsterModifiers/Src/Modifiers/ElementalInfusions.cs
+++ b/MonsterModifiers/Src/Modifiers/ElementalInfusions.cs
@@ -33,32 +33,27 @@ public class ElementalInfusions
                 return;
             }
 
-            float addedDamage = hit.GetTotalDamage() * 0.5f;
+            float totalDamage = hit.GetTotalDamage();
             float nonPlayerDamage = hit.m_damage.m_chop + hit.m_damage.m_pickaxe + hit.m_damage.m_spirit;
-            float finalDamageAdd = addedDamage - nonPlayerDamage;
 
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.PoisonInfused))
             {
-                hit.m_damage.m_poison += finalDamageAdd;
-                // Debug.Log("Hit has additional poison damage added. Amount is: " + hit.m_damage.m_poison);
+                hit.m_damage.m_poison += Mathf.Max(0f, totalDamage * (MonsterModifiersPlugin.Cfg_PoisonInfused_DamagePercent.Value / 100f) - nonPlayerDamage);
             }
-            
+
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.FireInfused))
             {
-                hit.m_damage.m_fire += finalDamageAdd;
-                // Debug.Log("Hit has additional fire damage added. Amount is: " + hit.m_damage.m_fire);
+                hit.m_damage.m_fire += Mathf.Max(0f, totalDamage * (MonsterModifiersPlugin.Cfg_FireInfused_DamagePercent.Value / 100f) - nonPlayerDamage);
             }
-            
+
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.LightningInfused))
             {
-                hit.m_damage.m_lightning += finalDamageAdd;
-                // Debug.Log("Hit has additional lightning damage added. Amount is: " + hit.m_damage.m_lightning);
+                hit.m_damage.m_lightning += Mathf.Max(0f, totalDamage * (MonsterModifiersPlugin.Cfg_LightningInfused_DamagePercent.Value / 100f) - nonPlayerDamage);
             }
-            
+
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.FrostInfused))
             {
-                hit.m_damage.m_frost += finalDamageAdd;
-                // Debug.Log("Hit has additional frost damage added. Amount is: " + hit.m_damage.m_frost);
+                hit.m_damage.m_frost += Mathf.Max(0f, totalDamage * (MonsterModifiersPlugin.Cfg_FrostInfused_DamagePercent.Value / 100f) - nonPlayerDamage);
             }
         }
     }

--- a/MonsterModifiers/Src/Modifiers/FastAttackSpeed.cs
+++ b/MonsterModifiers/Src/Modifiers/FastAttackSpeed.cs
@@ -25,9 +25,8 @@ public class FastAttackSpeed
 
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.FastAttackSpeed))
             {
-                // Debug.Log("Monster has fast attack speed");
                 double currentAttackSpeed = ___m_animator.speed * 10000000.0 % 100.0;
-                float attackSpeedModifier = 0.5f;
+                float attackSpeedModifier = MonsterModifiersPlugin.Cfg_FastAttackSpeed_SpeedPercent.Value / 100f;
                 if ((!(currentAttackSpeed < 30.0) || !(currentAttackSpeed > 10.0)) && !(___m_animator.speed <= 0.001f))
                 {
                     ___m_animator.speed = ___m_animator.speed * (1f + attackSpeedModifier) + 1.9E-06f;
@@ -56,7 +55,7 @@ public class FastAttackSpeed
             {
                 if (!character.IsPlayer() && __result && !character.IsBoss())
                 {
-                    float speedModifier = 0.5f;
+                    float speedModifier = MonsterModifiersPlugin.Cfg_FastAttackSpeed_SpeedPercent.Value / 100f;
                     weapon.m_lastAttackTime -= weapon.m_shared.m_aiAttackInterval * Mathf.Max(0f, speedModifier);
                 }
             }

--- a/MonsterModifiers/Src/Modifiers/FastMovement.cs
+++ b/MonsterModifiers/Src/Modifiers/FastMovement.cs
@@ -6,18 +6,17 @@ public class FastMovement
 {
     public static void AddFastMovement(Character character)
     {
-        // Debug.Log("Monster with name " + character.m_name + " has modifier Fast Movement");
-        
-        character.m_speed *= 1.5f;
-        character.m_runSpeed *= 1.5f;
-        character.m_walkSpeed *= 1.5f;
+        float speedMult = 1f + MonsterModifiersPlugin.Cfg_FastMovement_SpeedPercent.Value / 100f;
+        character.m_speed *= speedMult;
+        character.m_runSpeed *= speedMult;
+        character.m_walkSpeed *= speedMult;
     }
-    
+
     public static void RemoveFastMovement(Character character)
     {
-        // Debug.Log("Monster with name " + character.m_name + " has modifier Fast Movement");
-        character.m_speed /= 1.5f;
-        character.m_runSpeed /= 1.5f;
-        character.m_walkSpeed /= 1.5f;
+        float speedMult = 1f + MonsterModifiersPlugin.Cfg_FastMovement_SpeedPercent.Value / 100f;
+        character.m_speed /= speedMult;
+        character.m_runSpeed /= speedMult;
+        character.m_walkSpeed /= speedMult;
     }
 }

--- a/MonsterModifiers/Src/Modifiers/FireTrail.cs
+++ b/MonsterModifiers/Src/Modifiers/FireTrail.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+// 시너지: FireInfused + FastAttackSpeed → 이동 시 화염 흔적 파티클
+public class FireTrail : MonoBehaviour
+{
+    private Character _character;
+    private Vector3 _lastPosition;
+    private float _spawnInterval = 0.4f;
+    private float _minMoveDistance = 0.5f;
+    private float _timer;
+
+    private GameObject _fireVfxPrefab;
+
+    public void Initialize(Character character)
+    {
+        _character = character;
+        _lastPosition = character.transform.position;
+
+        // 게임 내 불꽃 파티클 프리팹 사용
+        _fireVfxPrefab = ZNetScene.instance?.GetPrefab("vfx_fire_emitter");
+        if (_fireVfxPrefab == null)
+            _fireVfxPrefab = ZNetScene.instance?.GetPrefab("fx_fireskeleton_nova");
+    }
+
+    private void Update()
+    {
+        if (_character == null || _fireVfxPrefab == null) return;
+
+        _timer += Time.deltaTime;
+        if (_timer < _spawnInterval) return;
+        _timer = 0f;
+
+        float moved = Vector3.Distance(_character.transform.position, _lastPosition);
+        if (moved < _minMoveDistance) return;
+
+        _lastPosition = _character.transform.position;
+        Vector3 spawnPos = _character.transform.position + Vector3.down * 0.3f;
+        GameObject trail = Instantiate(_fireVfxPrefab, spawnPos, Quaternion.identity);
+
+        // 1.5초 후 자동 제거
+        Destroy(trail, 1.5f);
+    }
+}

--- a/MonsterModifiers/Src/Modifiers/FoodDrain.cs
+++ b/MonsterModifiers/Src/Modifiers/FoodDrain.cs
@@ -47,7 +47,7 @@ public class FoodDrain
                 if (foodCount > 0)
                 {
                     int randomNumber = Random.Range(0, foodCount);
-                    playerFoods[randomNumber].m_time *= 0.5f;
+                    playerFoods[randomNumber].m_time *= (1f - MonsterModifiersPlugin.Cfg_FoodDrain_FoodReduction.Value / 100f);
                 }
             }
         }

--- a/MonsterModifiers/Src/Modifiers/Forceful.cs
+++ b/MonsterModifiers/Src/Modifiers/Forceful.cs
@@ -35,7 +35,7 @@ public class Forceful
 
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.Forceful))
             {
-                hit.m_pushForce *= 5.0f;
+                hit.m_pushForce *= MonsterModifiersPlugin.Cfg_Forceful_PushMultiplier.Value;
             }
             
         }

--- a/MonsterModifiers/Src/Modifiers/IgnoreArmor.cs
+++ b/MonsterModifiers/Src/Modifiers/IgnoreArmor.cs
@@ -47,8 +47,7 @@ public class IgnoreArmor
         {
             if (shouldIgnoreArmor)
             {
-                __result *= 0.5f;
-                // Debug.Log("Get body armor has reduced the armor");
+                __result *= (1f - MonsterModifiersPlugin.Cfg_IgnoreArmor_ArmorReduction.Value / 100f);
                 shouldIgnoreArmor = false;
             }
         }

--- a/MonsterModifiers/Src/Modifiers/Knockback.cs
+++ b/MonsterModifiers/Src/Modifiers/Knockback.cs
@@ -1,0 +1,38 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+public class Knockback
+{
+    [HarmonyPatch(typeof(Character), nameof(Character.RPC_Damage))]
+    public class Knockback_Character_RPC_Damage_Patch
+    {
+        public static void Prefix(Character __instance, HitData hit)
+        {
+            if (hit == null || __instance == null) return;
+            if (hit.m_damage.GetTotalDamage() == 0) return;
+            if (!__instance.IsPlayer()) return;
+
+            var attacker = hit.GetAttacker();
+            if (attacker == null || attacker.IsPlayer()) return;
+            if (__instance.IsBlocking()) return;
+
+            var modiferComponent = attacker.GetComponent<Custom_Components.MonsterModifier>();
+            if (modiferComponent == null || !modiferComponent.Modifiers.Contains(MonsterModifierTypes.Knockback))
+                return;
+
+            hit.m_pushForce = MonsterModifiersPlugin.Cfg_Knockback_StaggerForce.Value;
+
+            Vector3 knockDir = hit.m_dir;
+            if (knockDir.sqrMagnitude < 0.01f)
+                knockDir = (__instance.transform.position - attacker.transform.position).normalized;
+            knockDir.y = 0.3f;
+            knockDir.Normalize();
+
+            float forceMagnitude = MonsterModifiersPlugin.Cfg_Knockback_PushForce.Value;
+            if (__instance.m_pushForce.magnitude < forceMagnitude)
+                __instance.m_pushForce = knockDir * forceMagnitude;
+        }
+    }
+}

--- a/MonsterModifiers/Src/Modifiers/RemoveStatusEffect.cs
+++ b/MonsterModifiers/Src/Modifiers/RemoveStatusEffect.cs
@@ -40,6 +40,11 @@ public class RemoveStatusEffect
                 return;
             }
 
+            if (Random.value * 100f > MonsterModifiersPlugin.Cfg_RemoveStatusEffect_Chance.Value)
+            {
+                return;
+            }
+
             List<StatusEffect> playerStatusEffects = __instance.GetSEMan().GetStatusEffects();
             if (playerStatusEffects.Count > 1)
             {

--- a/MonsterModifiers/Src/Modifiers/ResistanceNotification.cs
+++ b/MonsterModifiers/Src/Modifiers/ResistanceNotification.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using HarmonyLib;
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+// 저항 몬스터 첫 타격/두 번째 타격 시 화면 중앙 메시지 표시, 세 번째부터 표시 없음
+public class ResistanceNotification
+{
+    // 몬스터 ZDOID → 해당 속성별 경고 표시 횟수 (최대 2회)
+    private static readonly Dictionary<ZDOID, Dictionary<string, int>> HitWarningCounts = new();
+
+    [HarmonyPatch(typeof(Character), nameof(Character.RPC_Damage))]
+    public class ResistanceNotification_Character_RPC_Damage_Patch
+    {
+        public static void Prefix(Character __instance, HitData hit)
+        {
+            if (hit == null || __instance == null)
+                return;
+
+            if (hit.m_damage.GetTotalDamage() == 0)
+                return;
+
+            // 피격 대상이 플레이어면 제외 (몬스터가 피격 대상이어야 함)
+            if (__instance.IsPlayer())
+                return;
+
+            var attacker = hit.GetAttacker();
+            if (attacker == null || !attacker.IsPlayer())
+                return;
+
+            // 로컬 플레이어가 공격한 경우만 메시지 표시
+            if (attacker != Player.m_localPlayer)
+                return;
+
+            var modiferComponent = __instance.GetComponent<Custom_Components.MonsterModifier>();
+            if (modiferComponent == null || modiferComponent.Modifiers.Count == 0)
+                return;
+
+            ZDOID zdoid = __instance.GetZDOID();
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.PierceImmunity) && hit.m_damage.m_pierce > 0)
+                TryShowWarning(zdoid, "pierce", "이 몬스터는 관통 공격에 강합니다! 참격 또는 둔기 공격을 사용하세요.");
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.SlashImmunity) && hit.m_damage.m_slash > 0)
+                TryShowWarning(zdoid, "slash", "이 몬스터는 베기 공격에 강합니다! 관통 또는 둔기 공격을 사용하세요.");
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.BluntImmunity) && hit.m_damage.m_blunt > 0)
+                TryShowWarning(zdoid, "blunt", "이 몬스터는 둔기 공격에 강합니다! 관통 또는 베기 공격을 사용하세요.");
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.ElementalImmunity))
+            {
+                float elemDmg = hit.m_damage.m_fire + hit.m_damage.m_frost + hit.m_damage.m_lightning
+                    + hit.m_damage.m_poison + hit.m_damage.m_spirit;
+                if (elemDmg > 0)
+                    TryShowWarning(zdoid, "elemental", "이 몬스터는 원소 공격에 강합니다! 물리 공격을 사용하세요.");
+            }
+        }
+
+        private static void TryShowWarning(ZDOID zdoid, string damageKey, string message)
+        {
+            if (!HitWarningCounts.ContainsKey(zdoid))
+                HitWarningCounts[zdoid] = new Dictionary<string, int>();
+
+            var counts = HitWarningCounts[zdoid];
+            if (!counts.ContainsKey(damageKey))
+                counts[damageKey] = 0;
+
+            if (counts[damageKey] < 2)
+            {
+                MessageHud.instance.ShowMessage(MessageHud.MessageType.Center, message);
+                counts[damageKey]++;
+            }
+        }
+    }
+
+    // 몬스터 사망 시 카운트 초기화
+    [HarmonyPatch(typeof(Character), nameof(Character.OnDeath))]
+    public class ResistanceNotification_Character_OnDeath_Patch
+    {
+        public static void Prefix(Character __instance)
+        {
+            if (__instance == null) return;
+            ZDOID zdoid = __instance.GetZDOID();
+            HitWarningCounts.Remove(zdoid);
+        }
+    }
+}

--- a/MonsterModifiers/Src/Modifiers/ShieldBreaker.cs
+++ b/MonsterModifiers/Src/Modifiers/ShieldBreaker.cs
@@ -36,7 +36,7 @@ public class ShieldBreaker
             {
                 if (shield.m_durability > (shield.GetMaxDurability() * 0.1))
                 {
-                    shield.m_durability *= 0.5f;  
+                    shield.m_durability *= (1f - MonsterModifiersPlugin.Cfg_ShieldBreaker_DurabilityReduction.Value / 100f);
                 }
             }
         }

--- a/MonsterModifiers/Src/Modifiers/SoulEater.cs
+++ b/MonsterModifiers/Src/Modifiers/SoulEater.cs
@@ -47,10 +47,11 @@ public class SoulEater : MonoBehaviour
                          int soulEaterCount = character.m_nview.GetZDO().GetInt("MM_soulEaterCount") + 1;
                          character.m_nview.GetZDO().Set("MM_soulEaterCount",soulEaterCount);
                          
-                         character.transform.localScale *= 1.1f;
+                         float growthMult = 1f + MonsterModifiersPlugin.Cfg_SoulEater_GrowthPerStack.Value / 100f;
+                         character.transform.localScale *= growthMult;
                          Physics.SyncTransforms();
 
-                         character.m_health *= 1.1f;
+                         character.m_health *= growthMult;
                      }
                  }
              }
@@ -82,35 +83,12 @@ public class SoulEater : MonoBehaviour
 
              if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.SoulEater))
              {
-                 if (attacker.m_nview.GetZDO().GetInt("MM_soulEaterCount") > 0)
+                 int soulEaterCount = attacker.m_nview.GetZDO().GetInt("MM_soulEaterCount");
+                 if (soulEaterCount > 0)
                  {
-                     int soulEaterCount = attacker.m_nview.GetZDO().GetInt("MM_soulEaterCount");
-                     float baseDamage = hit.GetTotalDamage();
-                     float finalDamage = baseDamage;
-                     switch (soulEaterCount)
-                     {
-                         case 1:
-                             hit.ApplyModifier(1.1f);
-                             finalDamage = baseDamage * 1.1f;
-                             // Debug.Log($"SoulEater modifier applied: 1.1. Final damage: {finalDamage}");
-                             break;
-                         case 2:
-                             hit.ApplyModifier(1.2f);
-                             finalDamage = baseDamage * 1.2f;
-                             // Debug.Log($"SoulEater modifier applied: 1.2. Final damage: {finalDamage}");
-                             break;
-                         case 3:
-                             hit.ApplyModifier(1.3f);
-                             finalDamage = baseDamage * 1.3f;
-                             // Debug.Log($"SoulEater modifier applied: 1.3. Final damage: {finalDamage}");
-                             break;
-                         default:
-                             // Handle cases where soulEaterCount is outside the range 1-3
-                             hit.ApplyModifier(1.0f); // No modifier or a default modifier
-                             finalDamage = baseDamage * 1.0f;
-                             // Debug.Log($"SoulEater modifier applied: 1.0 (default). Final damage: {finalDamage}");
-                             break;
-                     }
+                     float growthPct = MonsterModifiersPlugin.Cfg_SoulEater_GrowthPerStack.Value / 100f;
+                     float damageModifier = 1f + growthPct * Mathf.Clamp(soulEaterCount, 1, 3);
+                     hit.ApplyModifier(damageModifier);
                  }
              }
          }

--- a/MonsterModifiers/Src/Modifiers/StaminaSiphon.cs
+++ b/MonsterModifiers/Src/Modifiers/StaminaSiphon.cs
@@ -38,7 +38,7 @@ public class StaminaSiphon
                 return;
             }
             
-            __instance.UseStamina(hit.GetTotalDamage());
+            __instance.UseStamina(hit.GetTotalDamage() * (MonsterModifiersPlugin.Cfg_StaminaSiphon_DrainPercent.Value / 100f));
             // __instance.UseStamina(1);
         }
     }

--- a/MonsterModifiers/Src/Modifiers/Vampiric.cs
+++ b/MonsterModifiers/Src/Modifiers/Vampiric.cs
@@ -33,14 +33,15 @@ public class Vampiric
                 return;
             }
 
-            float addedDamage = hit.GetTotalDamage() * 0.5f;
+            float addedDamage = hit.GetTotalDamage() * (MonsterModifiersPlugin.Cfg_Vampiric_HealPercent.Value / 100f);
             float nonPlayerDamage = hit.m_damage.m_chop + hit.m_damage.m_pickaxe + hit.m_damage.m_spirit;
             float finalDamage = addedDamage - nonPlayerDamage;
             
             if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.Vampiric))
             {
-                attacker.Heal(finalDamage);
-                // Debug.Log("Hit has additional frost damage added. Amount is: " + hit.m_damage.m_frost);
+                // 시너지: Vampiric + Absorption 동시 보유 시 회복량 1.5배
+                float healMult = modiferComponent.Modifiers.Contains(MonsterModifierTypes.Absorption) ? 1.5f : 1.0f;
+                attacker.Heal(finalDamage * healMult);
             }
         }
     }

--- a/MonsterModifiers/Src/Modifiers/Wet.cs
+++ b/MonsterModifiers/Src/Modifiers/Wet.cs
@@ -39,7 +39,12 @@ public class Wet
             {
                 return;
             }
-            
+
+            if (Random.value * 100f > MonsterModifiersPlugin.Cfg_Wet_ApplyChance.Value)
+            {
+                return;
+            }
+
             __instance.GetSEMan().AddStatusEffect("Wet".GetStableHashCode());
         }
     }

--- a/MonsterModifiers/Src/Patches/AddMonsterModifiersToCharacter.cs
+++ b/MonsterModifiers/Src/Patches/AddMonsterModifiersToCharacter.cs
@@ -14,8 +14,18 @@ public class AddMonsterModifiersToCharacter
             if (!__instance.IsPlayer() && !__instance.IsBoss())
             {
                 __instance.gameObject.AddComponent<MonsterModifier>();
-                // Debug.Log("Monster Modifier component was added to creature with name " + __instance.m_name);
             }
+        }
+    }
+
+    // 소환 직후 Animator 미초기화 상태에서 ExtraStats 등 외부 모드가 접근할 때
+    // NullReferenceException 방지용 가드
+    [HarmonyPatch(typeof(Character), "UpdateCachedAnimHashes")]
+    public static class Character_UpdateCachedAnimHashes_Guard
+    {
+        private static bool Prefix(Character __instance)
+        {
+            return __instance.m_animator != null && __instance.m_animator.isInitialized;
         }
     }
 }

--- a/MonsterModifiers/Src/Patches/EnemyHudPatch.cs
+++ b/MonsterModifiers/Src/Patches/EnemyHudPatch.cs
@@ -36,42 +36,45 @@ namespace MonsterModifiers.Patches
 			{
 				return;
 			}
-			
-			// Debug.Log("Count of modifiers is " + modifiers.Count);
+
+			if (modifiers.Count == 0)
+			{
+				return;
+			}
 
 			GameObject creatureGUI = value.m_gui;
-			// Debug.Log("Name of creatureGUI is " + creatureGUI.name);
 
 			int startPosition = 0;
-			
+
 			// The maximum stars StarLevelsExpanded will allow on a creature HUD before truncated to a new star display format.
 			int starLevelsExpandedMaxStarOnHud = 7;
-			
+
 			if (CompatibilityUtils.isStarLevelsExpandedInstalled && character.GetLevel() > starLevelsExpandedMaxStarOnHud)
 			{
 				startPosition = 2;
 			}
-			
+
+			int characterLevel = character.GetLevel();
+
 			for (int i = startPosition; i < creatureGUI.transform.childCount; i++)
 			{
 				Transform child = creatureGUI.transform.GetChild(i);
-				if (child.name.StartsWith("level_"+(modifiers.Count+1)) || child.name.StartsWith("level_n") && child.gameObject.activeSelf)
+				if (child.name.StartsWith("level_" + characterLevel) || child.name.StartsWith("level_n") && child.gameObject.activeSelf)
 				{
-					// Debug.Log("Name of child at high index " + i + " is " + child.name);
-					for (int j = 0; j < child.transform.childCount; j++) {
+					for (int j = 0; j < child.transform.childCount; j++)
+					{
 						Transform child2 = child.transform.GetChild(j);
-						// Only modify stars, dont care about other componets in here
-						if (child2.name.StartsWith("star") && child2.gameObject.activeSelf) {
-                            child2.GetComponent<Image>().sprite =
-                            ModifierUtils.GetModifierIcon(modifiers[Mathf.Min(j, character.GetLevel() - 2)]);
-                            child2.GetComponent<Image>().color =
-                                ModifierUtils.GetModifierColor(modifiers[Mathf.Min(j, character.GetLevel() - 2)]);
-                            child2.GetChild(0).gameObject.SetActive(false);
-                        }
+						if (child2.name.StartsWith("star") && child2.gameObject.activeSelf)
+						{
+							int modIdx = Mathf.Min(j, modifiers.Count - 1);
+							child2.GetComponent<Image>().sprite = ModifierUtils.GetModifierIcon(modifiers[modIdx]);
+							child2.GetComponent<Image>().color = ModifierUtils.GetModifierColor(modifiers[modIdx]);
+							child2.GetChild(0).gameObject.SetActive(false);
+						}
 					}
 				}
 			}
-			
+
 		}
 	}
 }

--- a/MonsterModifiers/Src/Patches/ShaderLogFilter.cs
+++ b/MonsterModifiers/Src/Patches/ShaderLogFilter.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Logging;
+
+namespace MonsterModifiers.Patches;
+
+public static class ShaderLogFilter
+{
+    public static void Apply()
+    {
+        var existing = Logger.Listeners.ToList();
+        Logger.Listeners.Clear();
+        Logger.Listeners.Add(new FilteringListener(existing));
+    }
+
+    private sealed class FilteringListener : ILogListener
+    {
+        private readonly List<ILogListener> _inner;
+
+        public FilteringListener(List<ILogListener> inner) => _inner = inner;
+
+        public void LogEvent(object sender, LogEventArgs e)
+        {
+            if (e.Level == LogLevel.Warning &&
+                e.Data?.ToString()?.StartsWith("Failed to find expected binary shader data") == true)
+                return;
+            foreach (var l in _inner) l.LogEvent(sender, e);
+        }
+
+        public void Dispose()
+        {
+            foreach (var l in _inner) l.Dispose();
+        }
+    }
+}

--- a/MonsterModifiers/Src/Plugin.cs
+++ b/MonsterModifiers/Src/Plugin.cs
@@ -12,6 +12,7 @@ using Jotunn.Managers;
 using Jotunn.Utils;
 using LocalizationManager;
 using MonsterModifiers.Modifiers;
+using MonsterModifiers.Patches;
 using UnityEngine;
 using Paths = BepInEx.Paths;
 
@@ -21,8 +22,8 @@ namespace MonsterModifiers
     public class MonsterModifiersPlugin : BaseUnityPlugin
     {
         internal const string ModName = "MonsterModifiers";
-        internal const string ModVersion = "1.2.6";
-        internal const string Author = "warpalicious";
+        internal const string ModVersion = "1.3.1";
+        internal const string Author = "KorCaptain";
         private const string ModGUID = Author + "." + ModName;
         private static string ConfigFileName = ModGUID + ".cfg";
         private static string ConfigFileFullPath = Paths.ConfigPath + Path.DirectorySeparatorChar + ConfigFileName;
@@ -52,6 +53,8 @@ namespace MonsterModifiers
             Config.SaveOnConfigSet =
                 false; // This and the variable above are used to prevent the config from saving on startup for each config entry. This is speeds up the startup process.
 
+            ShaderLogFilter.Apply();
+
             Assembly assembly = Assembly.GetExecutingAssembly();
             _harmony.PatchAll(assembly);
             SetupWatcher();
@@ -66,9 +69,80 @@ namespace MonsterModifiers
             TranslationUtils.AddLocalizations();
             ModifierAssetUtils.Setup();
             ModifierAssetUtils.LoadAllIcons();
-            
-            Configurations_MaxModifiers = ConfigFileExtensions.BindConfig(Config, "Balance", "Max Modifiers",5,"The maximum amount of modifiers a creature can have.", true);
-            
+
+            Configurations_MaxModifiers = Config.Bind("Balance", "Max Modifiers", 5,
+                new ConfigDescription(L("몬스터 1마리당 최대 속성 수 (0=속성 없음, 5=최대 5개)", "Max modifier count per monster (0=none, 5=max 5)"), new AcceptableValueRange<int>(0, 5)));
+
+            // === Modifier_Offense ===
+            Cfg_StaminaSiphon_DrainPercent = Config.Bind("Modifier_Offense", "StaminaSiphon Drain %", 100,
+                new ConfigDescription(L("데미지의 N%만큼 스태미나 흡수 (0=없음, 100=데미지와 동일)", "Drain N% of damage dealt as stamina (0=none, 100=equal to damage)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_EitrSiphon_DrainPercent = Config.Bind("Modifier_Offense", "EitrSiphon Drain %", 100,
+                new ConfigDescription(L("데미지의 N%만큼 에이트르 흡수 (0=없음, 100=데미지와 동일)", "Drain N% of damage dealt as Eitr (0=none, 100=equal to damage)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_ShieldBreaker_DurabilityReduction = Config.Bind("Modifier_Offense", "ShieldBreaker Durability Reduction %", 50,
+                new ConfigDescription(L("막을 때 방패 내구도를 N% 감소 (50=절반으로 감소)", "Reduce shield durability by N% on block (50=half)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_IgnoreArmor_ArmorReduction = Config.Bind("Modifier_Offense", "IgnoreArmor Armor Reduction %", 50,
+                new ConfigDescription(L("공격 시 플레이어 방어력을 N% 무시 (50=절반 무시)", "Ignore N% of player armor on hit (50=half)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_FoodDrain_FoodReduction = Config.Bind("Modifier_Offense", "FoodDrain Food Time Reduction %", 50,
+                new ConfigDescription(L("랜덤 음식 하나의 지속시간을 N% 감소 (50=절반으로)", "Reduce a random food item's remaining time by N% (50=half)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_FireInfused_DamagePercent = Config.Bind("Modifier_Offense", "FireInfused Bonus Damage %", 50,
+                new ConfigDescription(L("총 데미지의 N%를 화염 피해로 추가 (50=절반 추가)", "Add N% of total damage as bonus fire damage (50=half)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_FrostInfused_DamagePercent = Config.Bind("Modifier_Offense", "FrostInfused Bonus Damage %", 50,
+                new ConfigDescription(L("총 데미지의 N%를 냉기 피해로 추가", "Add N% of total damage as bonus frost damage"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_PoisonInfused_DamagePercent = Config.Bind("Modifier_Offense", "PoisonInfused Bonus Damage %", 50,
+                new ConfigDescription(L("총 데미지의 N%를 독 피해로 추가", "Add N% of total damage as bonus poison damage"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_LightningInfused_DamagePercent = Config.Bind("Modifier_Offense", "LightningInfused Bonus Damage %", 50,
+                new ConfigDescription(L("총 데미지의 N%를 번개 피해로 추가", "Add N% of total damage as bonus lightning damage"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_FastAttackSpeed_SpeedPercent = Config.Bind("Modifier_Offense", "FastAttackSpeed Speed %", 50,
+                new ConfigDescription(L("공격 애니메이션 속도 N% 증가 (50=1.5배)", "Increase attack animation speed by N% (50=1.5x)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_Knockback_StaggerForce = Config.Bind("Modifier_Offense", "Knockback Stagger Force", 500,
+                new ConfigDescription(L("넉백 시 경직 강도 플랫값 (기본 500)", "Flat stagger force applied on knockback hit (default 500)"), new AcceptableValueRange<int>(0, 2000)));
+            Cfg_Knockback_PushForce = Config.Bind("Modifier_Offense", "Knockback Push Force", 45,
+                new ConfigDescription(L("넉백 시 밀침 거리 플랫값 (기본 45)", "Flat push force magnitude for knockback (default 45)"), new AcceptableValueRange<int>(0, 200)));
+            Cfg_Forceful_PushMultiplier = Config.Bind("Modifier_Offense", "Forceful Push Multiplier", 5.0f,
+                new ConfigDescription(L("기본 밀침력에 N배 적용 (기본 5.0)", "Multiply base push force by N (default 5.0)"), new AcceptableValueRange<float>(0f, 20f)));
+            Cfg_Wet_ApplyChance = Config.Bind("Modifier_Offense", "Wet Apply Chance %", 100,
+                new ConfigDescription(L("공격 시 물에 젖음 상태 적용 확률 (0=없음, 100=항상)", "Chance to apply Wet status on hit (0=never, 100=always)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_RemoveStatusEffect_Chance = Config.Bind("Modifier_Offense", "RemoveStatusEffect Chance %", 100,
+                new ConfigDescription(L("공격 시 랜덤 상태효과 제거 발동 확률 (0=없음, 100=항상)", "Chance to remove a random status effect on hit (0=never, 100=always)"), new AcceptableValueRange<int>(0, 100)));
+
+            // === Modifier_Defense ===
+            Cfg_PierceImmunity_DamageReduction = Config.Bind("Modifier_Defense", "PierceImmunity Damage Reduction %", 70,
+                new ConfigDescription(L("관통 피해 N% 감소 (70=30%만 받음)", "Reduce pierce damage by N% (70=take only 30%)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_SlashImmunity_DamageReduction = Config.Bind("Modifier_Defense", "SlashImmunity Damage Reduction %", 70,
+                new ConfigDescription(L("베기 피해 N% 감소", "Reduce slash damage by N%"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_BluntImmunity_DamageReduction = Config.Bind("Modifier_Defense", "BluntImmunity Damage Reduction %", 70,
+                new ConfigDescription(L("둔기 피해 N% 감소", "Reduce blunt damage by N%"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_ElementalImmunity_DamageReduction = Config.Bind("Modifier_Defense", "ElementalImmunity Damage Reduction %", 70,
+                new ConfigDescription(L("화염/냉기/번개/독/정신 피해 N% 감소", "Reduce fire/frost/lightning/poison/spirit damage by N%"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_FastMovement_SpeedPercent = Config.Bind("Modifier_Defense", "FastMovement Speed %", 50,
+                new ConfigDescription(L("이동/달리기/걷기 속도 N% 증가 (50=1.5배)", "Increase move/run/walk speed by N% (50=1.5x)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_DistantDetection_RangeMultiplier = Config.Bind("Modifier_Defense", "DistantDetection Range Multiplier", 2.0f,
+                new ConfigDescription(L("청각/시각 감지 범위 N배 (기본 2.0)", "Multiply hear/view detection range by N (default 2.0)"), new AcceptableValueRange<float>(1f, 5f)));
+
+            // === Modifier_Lifesteal ===
+            Cfg_Vampiric_HealPercent = Config.Bind("Modifier_Lifesteal", "Vampiric Heal %", 50,
+                new ConfigDescription(L("딜의 N%만큼 공격자 회복 (50=딜의 절반)", "Heal attacker for N% of damage dealt (50=half of damage)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_Absorption_HealPercent = Config.Bind("Modifier_Lifesteal", "Absorption Heal %", 70,
+                new ConfigDescription(L("저항으로 막은 피해의 N%만큼 회복 (면역 속성 보유 시)", "Heal for N% of damage absorbed by immunity modifiers"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_SoulEater_GrowthPerStack = Config.Bind("Modifier_Lifesteal", "SoulEater Growth Per Stack %", 10,
+                new ConfigDescription(L("주변 몬스터 사망 시 스택당 N% 성장 (크기/체력/데미지, 최대 3스택)", "Grow by N% per stack when nearby monsters die (size/health/damage, max 3 stacks)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_BloodLoss_BurstDamagePercent = Config.Bind("Modifier_Lifesteal", "BloodLoss Burst Damage %", 30,
+                new ConfigDescription(L("혈손 폭발 시 최대체력의 N% 베기 피해 (기본 30)", "Deal N% of max health as slash damage when BloodLoss bursts (default 30)"), new AcceptableValueRange<int>(0, 100)));
+
+            // === Modifier_Death ===
+            Cfg_PoisonDeath_DamagePercent = Config.Bind("Modifier_Death", "PoisonDeath Damage %", 50,
+                new ConfigDescription(L("사망 시 독 폭발 피해 (몬스터 공격력의 N%)", "Poison AOE damage on death (N% of monster attack power)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_FireDeath_DamagePercent = Config.Bind("Modifier_Death", "FireDeath Damage %", 50,
+                new ConfigDescription(L("사망 시 화염 폭발 피해 (몬스터 공격력의 N%)", "Fire nova damage on death (N% of monster attack power)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_FrostDeath_DamagePercent = Config.Bind("Modifier_Death", "FrostDeath Damage %", 50,
+                new ConfigDescription(L("사망 시 냉기 폭발 피해 (몬스터 공격력의 N%)", "Frost nova damage on death (N% of monster attack power)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_HealDeath_HealPercent = Config.Bind("Modifier_Death", "HealDeath Heal %", 75,
+                new ConfigDescription(L("사망 시 주변 몬스터에게 최대체력의 N% 치유 (기본 75)", "Heal nearby monsters for N% of max health on death (default 75)"), new AcceptableValueRange<int>(0, 100)));
+            Cfg_SummonDeath_ScalePercent = Config.Bind("Modifier_Death", "SummonDeath Scale %", 70,
+                new ConfigDescription(L("소환체 크기 (원본의 N%, 기본 70)", "Spawned minion scale as N% of parent (default 70)"), new AcceptableValueRange<int>(1, 100)));
+            Cfg_SummonDeath_HealthPercent = Config.Bind("Modifier_Death", "SummonDeath Health %", 70,
+                new ConfigDescription(L("소환체 체력 (원본의 N%, 기본 70)", "Spawned minion health as N% of parent (default 70)"), new AcceptableValueRange<int>(1, 100)));
+
             // ShieldDome.LoadShieldDome();
             
             CompatibilityUtils.RunCompatibiltyChecks();
@@ -78,8 +152,52 @@ namespace MonsterModifiers
             PrefabManager.OnVanillaPrefabsAvailable += PrefabUtils.CreateCustomPrefabs;
         }
         
-        public static ConfigEntry<int> Configurations_MaxModifiers;
+        public static ConfigEntry<int> Configurations_MaxModifiers = null!;
+
+        // Modifier_Offense
+        public static ConfigEntry<int> Cfg_StaminaSiphon_DrainPercent = null!;
+        public static ConfigEntry<int> Cfg_EitrSiphon_DrainPercent = null!;
+        public static ConfigEntry<int> Cfg_ShieldBreaker_DurabilityReduction = null!;
+        public static ConfigEntry<int> Cfg_IgnoreArmor_ArmorReduction = null!;
+        public static ConfigEntry<int> Cfg_FoodDrain_FoodReduction = null!;
+        public static ConfigEntry<int> Cfg_FireInfused_DamagePercent = null!;
+        public static ConfigEntry<int> Cfg_FrostInfused_DamagePercent = null!;
+        public static ConfigEntry<int> Cfg_PoisonInfused_DamagePercent = null!;
+        public static ConfigEntry<int> Cfg_LightningInfused_DamagePercent = null!;
+        public static ConfigEntry<int> Cfg_FastAttackSpeed_SpeedPercent = null!;
+        public static ConfigEntry<int> Cfg_Knockback_StaggerForce = null!;
+        public static ConfigEntry<int> Cfg_Knockback_PushForce = null!;
+        public static ConfigEntry<float> Cfg_Forceful_PushMultiplier = null!;
+        public static ConfigEntry<int> Cfg_Wet_ApplyChance = null!;
+        public static ConfigEntry<int> Cfg_RemoveStatusEffect_Chance = null!;
+
+        // Modifier_Defense
+        public static ConfigEntry<int> Cfg_PierceImmunity_DamageReduction = null!;
+        public static ConfigEntry<int> Cfg_SlashImmunity_DamageReduction = null!;
+        public static ConfigEntry<int> Cfg_BluntImmunity_DamageReduction = null!;
+        public static ConfigEntry<int> Cfg_ElementalImmunity_DamageReduction = null!;
+        public static ConfigEntry<int> Cfg_FastMovement_SpeedPercent = null!;
+        public static ConfigEntry<float> Cfg_DistantDetection_RangeMultiplier = null!;
+
+        // Modifier_Lifesteal
+        public static ConfigEntry<int> Cfg_Vampiric_HealPercent = null!;
+        public static ConfigEntry<int> Cfg_Absorption_HealPercent = null!;
+        public static ConfigEntry<int> Cfg_SoulEater_GrowthPerStack = null!;
+        public static ConfigEntry<int> Cfg_BloodLoss_BurstDamagePercent = null!;
+
+        // Modifier_Death
+        public static ConfigEntry<int> Cfg_PoisonDeath_DamagePercent = null!;
+        public static ConfigEntry<int> Cfg_FireDeath_DamagePercent = null!;
+        public static ConfigEntry<int> Cfg_FrostDeath_DamagePercent = null!;
+        public static ConfigEntry<int> Cfg_HealDeath_HealPercent = null!;
+        public static ConfigEntry<int> Cfg_SummonDeath_ScalePercent = null!;
+        public static ConfigEntry<int> Cfg_SummonDeath_HealthPercent = null!;
         
+
+        private static string L(string ko, string en)
+        {
+            return System.Globalization.CultureInfo.CurrentUICulture.Name.StartsWith("ko") ? ko : en;
+        }
 
         private void OnDestroy()
         {

--- a/MonsterModifiers/Src/StatusEffects/BloodLoss_SE.cs
+++ b/MonsterModifiers/Src/StatusEffects/BloodLoss_SE.cs
@@ -34,7 +34,7 @@ public class BloodLoss_SE : StatusEffect
             
             HitData bloodLossHit = new HitData
             {
-                m_damage = { m_slash = m_character.GetMaxHealth() * 0.30f }
+                m_damage = { m_slash = m_character.GetMaxHealth() * (MonsterModifiersPlugin.Cfg_BloodLoss_BurstDamagePercent.Value / 100f) }
             };
             
             m_character.Damage(bloodLossHit);

--- a/MonsterModifiers/Src/Utils/ModifierUtils.cs
+++ b/MonsterModifiers/Src/Utils/ModifierUtils.cs
@@ -40,7 +40,9 @@ public enum MonsterModifierTypes
     Vampiric,
     Forceful,
     Wet,
-    Quiet
+    Quiet,
+    Knockback,
+    SummonDeath
 }
 
 public class ModifierData
@@ -51,7 +53,7 @@ public class ModifierData
 
 public class ModifierUtils
 {
-    public static Dictionary<MonsterModifierTypes, ModifierData> modifiers;
+    public static Dictionary<MonsterModifierTypes, ModifierData> modifiers = null!;
 
     public static Color GetModifierColor(MonsterModifierTypes modifier)
     {
@@ -68,7 +70,8 @@ public class ModifierUtils
             modifier == MonsterModifierTypes.FrostInfused ||
             modifier == MonsterModifierTypes.PoisonInfused ||
             modifier == MonsterModifierTypes.LightningInfused ||
-            modifier == MonsterModifierTypes.RemoveStatusEffect)
+            modifier == MonsterModifierTypes.RemoveStatusEffect ||
+            modifier == MonsterModifierTypes.Knockback)
         {
             return ModifierAssetUtils.swordIcon;
         }
@@ -95,7 +98,8 @@ public class ModifierUtils
             modifier == MonsterModifierTypes.FrostDeath ||
             modifier == MonsterModifierTypes.HealDeath ||
             modifier == MonsterModifierTypes.StaggerDeath ||
-            modifier == MonsterModifierTypes.TarDeath)
+            modifier == MonsterModifierTypes.TarDeath ||
+            modifier == MonsterModifierTypes.SummonDeath)
         {
             return ModifierAssetUtils.skullIcon;
         }
@@ -141,7 +145,6 @@ public class ModifierUtils
             modifier == MonsterModifierTypes.FastMovement ||
             modifier == MonsterModifierTypes.DistantDetection ||
             modifier == MonsterModifierTypes.Forceful)
-
         {
             return ModifierAssetUtils.plusSquareIcon;
         }

--- a/MonsterModifiers/Src/Utils/PrefabUtils.cs
+++ b/MonsterModifiers/Src/Utils/PrefabUtils.cs
@@ -7,8 +7,8 @@ namespace MonsterModifiers;
 
 public class PrefabUtils
 {
-    public static GameObject leechDeathVFX;
-    public static GameObject leechDeathSFX;
+    public static GameObject leechDeathVFX = null!;
+    public static GameObject leechDeathSFX = null!;
     
     public static void CreateCustomPrefabs()
     {

--- a/MonsterModifiers/Src/Utils/SpawnCommands.cs
+++ b/MonsterModifiers/Src/Utils/SpawnCommands.cs
@@ -36,8 +36,7 @@ namespace MonsterModifiers
                 if (character.m_nview.GetZDO().IsOwner())
                 {
                     character.SetLevel(2);
-                    string serializedModifiers = string.Join(",", modifierName);
-                    character.m_nview.GetZDO().Set("modifiers", serializedModifiers);
+                    character.m_nview.GetZDO().Set("modifiers", modifierName);
                 }
             }
             else


### PR DESCRIPTION
## Summary

This PR adds 4 new modifiers and reworks the immunity system to use configurable percentage-based damage reduction instead of full immunity.

### New Modifiers

- **Knockback** — knocks back the target ~7m on hit; pushForce scales with `Monster Attack 효과 %` config
- **ArmorCharge** — grants stacking armor bonus on consecutive hits
- **FireTrail** — leaves a burning fire trail as the monster moves
- **ResistanceNotification** — notifies the player when a damage type is resisted

### Immunity → Configurable Resistance

`PierceImmunity`, `SlashImmunity`, `BluntImmunity`, and `ElementalImmunity` have been reworked from hard immunity to configurable percentage reduction:

```
// Before: full immunity (damage = 0)
// After: configurable reduction (default 70%)
hit.m_damage.m_pierce *= (1f - Cfg_PierceImmunity_DamageReduction.Value / 100f);
```

New config entries (0–100, default 70):
- `Cfg_PierceImmunity_DamageReduction`
- `Cfg_SlashImmunity_DamageReduction`  
- `Cfg_BluntImmunity_DamageReduction`
- `Cfg_ElementalImmunity_DamageReduction`

This makes combat with immune-type modifiers more engaging — players still need to switch damage types but aren't completely shut out.

### Other Changes

- **Absorption**: updated to use resistance modifier scaling with `healRatio`
- **AddMonsterModifiersToCharacter**: NRE guard added to `UpdateCachedAnimHashes` (prevents crash when external mods access `Animator` before initialization)
- **ShaderLogFilter**: suppresses noisy `shader missing keyword` log spam from BepInEx console
- **SpawnCommands**: adds `modifier [creature] [modifier]` terminal cheat command for testing

### Note on Plugin.cs

`Author` and `ModVersion` were updated during development — please revert to `warpalicious` / appropriate upstream versioning before merging if preferred.

## Test plan

- [ ] Spawn Knockback monster, verify ~7m pushback on hit
- [ ] Spawn ArmorCharge monster, verify stacking armor UI
- [ ] Spawn FireTrail monster, verify fire particles on ground
- [ ] Spawn PierceImmunity monster with `Defense % = 0` → full damage received
- [ ] Spawn PierceImmunity monster with `Defense % = 100` → 30% damage received
- [ ] No NRE in logs when other mods access Character on spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)