### PR TITLE
feat: add new modifiers — Knockback, ArmorCharge, FireTrail, ResistanceNotification

### DIFF
--- a/MonsterModifiers/Src/Modifiers/ArmorCharge.cs
+++ b/MonsterModifiers/Src/Modifiers/ArmorCharge.cs
@@ -1,0 +1,56 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+// 시너지: 관통+베기+둔기 저항 3종 + FastMovement = "철갑 돌격" 타입
+// 효과: 이동속도 추가 +30%, 공격 시 데미지 +50%
+public class ArmorCharge
+{
+    private const float ExtraSpeedMult = 1.3f;
+    private const float ExtraDamageMult = 1.5f;
+
+    public static bool IsArmorChargeType(Custom_Components.MonsterModifier modifier)
+    {
+        return modifier.Modifiers.Contains(MonsterModifierTypes.PierceImmunity)
+            && modifier.Modifiers.Contains(MonsterModifierTypes.SlashImmunity)
+            && modifier.Modifiers.Contains(MonsterModifierTypes.BluntImmunity)
+            && modifier.Modifiers.Contains(MonsterModifierTypes.FastMovement);
+    }
+
+    public static void ApplyArmorCharge(Character character)
+    {
+        character.m_speed *= ExtraSpeedMult;
+        character.m_runSpeed *= ExtraSpeedMult;
+        character.m_walkSpeed *= ExtraSpeedMult;
+    }
+
+    // 철갑 돌격 타입 몬스터의 공격 데미지 +50%
+    [HarmonyPatch(typeof(Character), nameof(Character.RPC_Damage))]
+    public class ArmorCharge_Character_RPC_Damage_Patch
+    {
+        public static void Prefix(Character __instance, HitData hit)
+        {
+            if (!ModifierUtils.RunRPCDamageChecks(__instance, hit))
+                return;
+
+            if (!ModifierUtils.RunHitChecks(hit, true))
+                return;
+
+            var attacker = hit.GetAttacker();
+            var modiferComponent = attacker?.GetComponent<Custom_Components.MonsterModifier>();
+            if (modiferComponent == null)
+                return;
+
+            if (!IsArmorChargeType(modiferComponent))
+                return;
+
+            hit.m_damage.m_blunt *= ExtraDamageMult;
+            hit.m_damage.m_slash *= ExtraDamageMult;
+            hit.m_damage.m_pierce *= ExtraDamageMult;
+            hit.m_damage.m_fire *= ExtraDamageMult;
+            hit.m_damage.m_frost *= ExtraDamageMult;
+            hit.m_damage.m_lightning *= ExtraDamageMult;
+        }
+    }
+}

--- a/MonsterModifiers/Src/Modifiers/FireTrail.cs
+++ b/MonsterModifiers/Src/Modifiers/FireTrail.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+// 시너지: FireInfused + FastAttackSpeed → 이동 시 화염 흔적 파티클
+public class FireTrail : MonoBehaviour
+{
+    private Character _character;
+    private Vector3 _lastPosition;
+    private float _spawnInterval = 0.4f;
+    private float _minMoveDistance = 0.5f;
+    private float _timer;
+
+    private GameObject _fireVfxPrefab;
+
+    public void Initialize(Character character)
+    {
+        _character = character;
+        _lastPosition = character.transform.position;
+
+        // 게임 내 불꽃 파티클 프리팹 사용
+        _fireVfxPrefab = ZNetScene.instance?.GetPrefab("vfx_fire_emitter");
+        if (_fireVfxPrefab == null)
+            _fireVfxPrefab = ZNetScene.instance?.GetPrefab("fx_fireskeleton_nova");
+    }
+
+    private void Update()
+    {
+        if (_character == null || _fireVfxPrefab == null) return;
+
+        _timer += Time.deltaTime;
+        if (_timer < _spawnInterval) return;
+        _timer = 0f;
+
+        float moved = Vector3.Distance(_character.transform.position, _lastPosition);
+        if (moved < _minMoveDistance) return;
+
+        _lastPosition = _character.transform.position;
+        Vector3 spawnPos = _character.transform.position + Vector3.down * 0.3f;
+        GameObject trail = Instantiate(_fireVfxPrefab, spawnPos, Quaternion.identity);
+
+        // 1.5초 후 자동 제거
+        Destroy(trail, 1.5f);
+    }
+}

--- a/MonsterModifiers/Src/Modifiers/Knockback.cs
+++ b/MonsterModifiers/Src/Modifiers/Knockback.cs
@@ -1,0 +1,38 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+public class Knockback
+{
+    [HarmonyPatch(typeof(Character), nameof(Character.RPC_Damage))]
+    public class Knockback_Character_RPC_Damage_Patch
+    {
+        public static void Prefix(Character __instance, HitData hit)
+        {
+            if (hit == null || __instance == null) return;
+            if (hit.m_damage.GetTotalDamage() == 0) return;
+            if (!__instance.IsPlayer()) return;
+
+            var attacker = hit.GetAttacker();
+            if (attacker == null || attacker.IsPlayer()) return;
+            if (__instance.IsBlocking()) return;
+
+            var modiferComponent = attacker.GetComponent<Custom_Components.MonsterModifier>();
+            if (modiferComponent == null || !modiferComponent.Modifiers.Contains(MonsterModifierTypes.Knockback))
+                return;
+
+            hit.m_pushForce = MonsterModifiersPlugin.Cfg_Knockback_StaggerForce.Value;
+
+            Vector3 knockDir = hit.m_dir;
+            if (knockDir.sqrMagnitude < 0.01f)
+                knockDir = (__instance.transform.position - attacker.transform.position).normalized;
+            knockDir.y = 0.3f;
+            knockDir.Normalize();
+
+            float forceMagnitude = MonsterModifiersPlugin.Cfg_Knockback_PushForce.Value;
+            if (__instance.m_pushForce.magnitude < forceMagnitude)
+                __instance.m_pushForce = knockDir * forceMagnitude;
+        }
+    }
+}

--- a/MonsterModifiers/Src/Modifiers/ResistanceNotification.cs
+++ b/MonsterModifiers/Src/Modifiers/ResistanceNotification.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using HarmonyLib;
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+// 저항 몬스터 첫 타격/두 번째 타격 시 화면 중앙 메시지 표시, 세 번째부터 표시 없음
+public class ResistanceNotification
+{
+    // 몬스터 ZDOID → 해당 속성별 경고 표시 횟수 (최대 2회)
+    private static readonly Dictionary<ZDOID, Dictionary<string, int>> HitWarningCounts = new();
+
+    [HarmonyPatch(typeof(Character), nameof(Character.RPC_Damage))]
+    public class ResistanceNotification_Character_RPC_Damage_Patch
+    {
+        public static void Prefix(Character __instance, HitData hit)
+        {
+            if (hit == null || __instance == null)
+                return;
+
+            if (hit.m_damage.GetTotalDamage() == 0)
+                return;
+
+            // 피격 대상이 플레이어면 제외 (몬스터가 피격 대상이어야 함)
+            if (__instance.IsPlayer())
+                return;
+
+            var attacker = hit.GetAttacker();
+            if (attacker == null || !attacker.IsPlayer())
+                return;
+
+            // 로컬 플레이어가 공격한 경우만 메시지 표시
+            if (attacker != Player.m_localPlayer)
+                return;
+
+            var modiferComponent = __instance.GetComponent<Custom_Components.MonsterModifier>();
+            if (modiferComponent == null || modiferComponent.Modifiers.Count == 0)
+                return;
+
+            ZDOID zdoid = __instance.GetZDOID();
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.PierceImmunity) && hit.m_damage.m_pierce > 0)
+                TryShowWarning(zdoid, "pierce", "이 몬스터는 관통 공격에 강합니다! 참격 또는 둔기 공격을 사용하세요.");
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.SlashImmunity) && hit.m_damage.m_slash > 0)
+                TryShowWarning(zdoid, "slash", "이 몬스터는 베기 공격에 강합니다! 관통 또는 둔기 공격을 사용하세요.");
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.BluntImmunity) && hit.m_damage.m_blunt > 0)
+                TryShowWarning(zdoid, "blunt", "이 몬스터는 둔기 공격에 강합니다! 관통 또는 베기 공격을 사용하세요.");
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.ElementalImmunity))
+            {
+                float elemDmg = hit.m_damage.m_fire + hit.m_damage.m_frost + hit.m_damage.m_lightning
+                    + hit.m_damage.m_poison + hit.m_damage.m_spirit;
+                if (elemDmg > 0)
+                    TryShowWarning(zdoid, "elemental", "이 몬스터는 원소 공격에 강합니다! 물리 공격을 사용하세요.");
+            }
+        }
+
+        private static void TryShowWarning(ZDOID zdoid, string damageKey, string message)
+        {
+            if (!HitWarningCounts.ContainsKey(zdoid))
+                HitWarningCounts[zdoid] = new Dictionary<string, int>();
+
+            var counts = HitWarningCounts[zdoid];
+            if (!counts.ContainsKey(damageKey))
+                counts[damageKey] = 0;
+
+            if (counts[damageKey] < 2)
+            {
+                MessageHud.instance.ShowMessage(MessageHud.MessageType.Center, message);
+                counts[damageKey]++;
+            }
+        }
+    }
+
+    // 몬스터 사망 시 카운트 초기화
+    [HarmonyPatch(typeof(Character), nameof(Character.OnDeath))]
+    public class ResistanceNotification_Character_OnDeath_Patch
+    {
+        public static void Prefix(Character __instance)
+        {
+            if (__instance == null) return;
+            ZDOID zdoid = __instance.GetZDOID();
+            HitWarningCounts.Remove(zdoid);
+        }
+    }
+}

--- a/MonsterModifiers/Src/Patches/AddMonsterModifiersToCharacter.cs
+++ b/MonsterModifiers/Src/Patches/AddMonsterModifiersToCharacter.cs
@@ -14,8 +14,18 @@ public class AddMonsterModifiersToCharacter
             if (!__instance.IsPlayer() && !__instance.IsBoss())
             {
                 __instance.gameObject.AddComponent<MonsterModifier>();
-                // Debug.Log("Monster Modifier component was added to creature with name " + __instance.m_name);
             }
+        }
+    }
+
+    // 소환 직후 Animator 미초기화 상태에서 ExtraStats 등 외부 모드가 접근할 때
+    // NullReferenceException 방지용 가드
+    [HarmonyPatch(typeof(Character), "UpdateCachedAnimHashes")]
+    public static class Character_UpdateCachedAnimHashes_Guard
+    {
+        private static bool Prefix(Character __instance)
+        {
+            return __instance.m_animator != null && __instance.m_animator.isInitialized;
         }
     }
 }

--- a/MonsterModifiers/Src/Patches/ShaderLogFilter.cs
+++ b/MonsterModifiers/Src/Patches/ShaderLogFilter.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Logging;
+
+namespace MonsterModifiers.Patches;
+
+public static class ShaderLogFilter
+{
+    public static void Apply()
+    {
+        var existing = Logger.Listeners.ToList();
+        Logger.Listeners.Clear();
+        Logger.Listeners.Add(new FilteringListener(existing));
+    }
+
+    private sealed class FilteringListener : ILogListener
+    {
+        private readonly List<ILogListener> _inner;
+
+        public FilteringListener(List<ILogListener> inner) => _inner = inner;
+
+        public void LogEvent(object sender, LogEventArgs e)
+        {
+            if (e.Level == LogLevel.Warning &&
+                e.Data?.ToString()?.StartsWith("Failed to find expected binary shader data") == true)
+                return;
+            foreach (var l in _inner) l.LogEvent(sender, e);
+        }
+
+        public void Dispose()
+        {
+            foreach (var l in _inner) l.Dispose();
+        }
+    }
+}

--- a/MonsterModifiers/Src/Plugin.cs
+++ b/MonsterModifiers/Src/Plugin.cs
@@ -12,6 +12,7 @@ using Jotunn.Managers;
 using Jotunn.Utils;
 using LocalizationManager;
 using MonsterModifiers.Modifiers;
+using MonsterModifiers.Patches;
 using UnityEngine;
 using Paths = BepInEx.Paths;
 
@@ -52,6 +53,8 @@ namespace MonsterModifiers
             Config.SaveOnConfigSet =
                 false; // This and the variable above are used to prevent the config from saving on startup for each config entry. This is speeds up the startup process.
 
+            ShaderLogFilter.Apply();
+
             Assembly assembly = Assembly.GetExecutingAssembly();
             _harmony.PatchAll(assembly);
             SetupWatcher();
@@ -68,7 +71,12 @@ namespace MonsterModifiers
             ModifierAssetUtils.LoadAllIcons();
             
             Configurations_MaxModifiers = ConfigFileExtensions.BindConfig(Config, "Balance", "Max Modifiers",5,"The maximum amount of modifiers a creature can have.", true);
-            
+
+            Cfg_Knockback_StaggerForce = Config.Bind("Modifier_Offense", "Knockback Stagger Force", 500,
+                new ConfigDescription("Flat stagger force applied on knockback hit (default 500)", new AcceptableValueRange<int>(0, 2000)));
+            Cfg_Knockback_PushForce = Config.Bind("Modifier_Offense", "Knockback Push Force", 45,
+                new ConfigDescription("Flat push force magnitude for knockback (default 45)", new AcceptableValueRange<int>(0, 200)));
+
             // ShieldDome.LoadShieldDome();
             
             CompatibilityUtils.RunCompatibiltyChecks();
@@ -79,7 +87,10 @@ namespace MonsterModifiers
         }
         
         public static ConfigEntry<int> Configurations_MaxModifiers;
-        
+
+        // Knockback config
+        public static ConfigEntry<int> Cfg_Knockback_StaggerForce = null!;
+        public static ConfigEntry<int> Cfg_Knockback_PushForce = null!;
 
         private void OnDestroy()
         {

--- a/MonsterModifiers/Src/Utils/SpawnCommands.cs
+++ b/MonsterModifiers/Src/Utils/SpawnCommands.cs
@@ -36,8 +36,7 @@ namespace MonsterModifiers
                 if (character.m_nview.GetZDO().IsOwner())
                 {
                     character.SetLevel(2);
-                    string serializedModifiers = string.Join(",", modifierName);
-                    character.m_nview.GetZDO().Set("modifiers", serializedModifiers);
+                    character.m_nview.GetZDO().Set("modifiers", modifierName);
                 }
             }
             else

--- a/Src/Custom Components/MonsterModifier.cs
+++ b/Src/Custom Components/MonsterModifier.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MonsterModifiers.Modifiers;
+using UnityEngine;
+using MonsterModifiers.Visuals;
+
+namespace MonsterModifiers.Custom_Components;
+
+public class MonsterModifier : MonoBehaviour
+{
+   public List<MonsterModifierTypes> Modifiers = new List<MonsterModifierTypes>();
+
+   public Character character = null!;
+
+   public int level;
+
+   // Set to true when attached to a boss character / 보스 캐릭터에 붙어 있을 때 true
+   public bool IsBossCharacter = false;
+   // Stars beyond the HUD icon slots; displayed as plain stars / HUD 아이콘 슬롯 초과 별 수
+   public int OverflowStars = 0;
+
+   private void Start()
+   {
+      character = GetComponent<Character>();
+      level = character.GetLevel();
+
+      // Skip Epic Loot bounty targets / Epic Loot 현상금 대상은 건너뜀
+      if (character.m_nview != null && character.m_nview.GetZDO().GetString("BountyID") != string.Empty)
+      {
+         Destroy(this);
+         return;
+      }
+
+      if (character.IsBoss())
+      {
+         if (MonsterModifiersPlugin.Configurations_Boss_Modifiers.Value == MonsterModifiersPlugin.Toggle.Off)
+            return;
+
+         IsBossCharacter = true;
+         // Stars determine modifier count, capped at boss_Modifiers_Max; remainder shown as plain stars
+         // 별 수 = 속성 수, boss_Modifiers_Max로 상한; 남은 별은 HUD에 별 아이콘으로 표시
+         int starCount = Mathf.Max(0, level - 1);
+         int actualCount = Mathf.Min(starCount, MonsterModifiersPlugin.Configurations_Boss_MaxModifiers.Value);
+         OverflowStars = starCount - actualCount;
+
+         string modifiersString = character.m_nview.GetZDO().GetString("modifiers", string.Empty);
+         if (string.IsNullOrEmpty(modifiersString))
+         {
+            foreach (var modifier in ModifierUtils.RollRandomModifiers(actualCount, ModifierUtils.BossExcludedModifiers))
+               Modifiers.Add(modifier);
+
+            if (character.m_nview.GetZDO().IsOwner())
+               character.m_nview.GetZDO().Set("modifiers", string.Join(",", Modifiers));
+         }
+         else
+         {
+            Modifiers = new List<MonsterModifierTypes>(Array.ConvertAll(modifiersString.Split(','),
+               str => (MonsterModifierTypes)Enum.Parse(typeof(MonsterModifierTypes), str)));
+
+            // Recalculate overflow in case MaxModifiers config changed
+            // MaxModifiers 컨피그가 변경된 경우를 대비해 overflow 재계산
+            int reloadedActual = Mathf.Min(starCount, MonsterModifiersPlugin.Configurations_Boss_MaxModifiers.Value);
+            OverflowStars = starCount - reloadedActual;
+         }
+
+         ApplyStartModifiers();
+         return;
+      }
+
+      if (level > 1)
+      {
+         string modifiersString = character.m_nview?.GetZDO()?.GetString("modifiers", string.Empty) ?? string.Empty;
+         if (string.IsNullOrEmpty(modifiersString))
+         {
+            // level - 1 so a 2-star monster gets 1 modifier, 3-star gets 2, etc.
+            // level - 1: ★2 몬스터 = 속성 1개, ★3 = 2개
+            int numModifiers = Mathf.Min(level - 1, MonsterModifiersPlugin.Configurations_MaxModifiers.Value);
+
+            foreach (var modifier in ModifierUtils.RollRandomModifiers(numModifiers))
+               Modifiers.Add(modifier);
+
+            if (character.m_nview.GetZDO().IsOwner())
+            {
+               string serializedModifiers = string.Join(",", Modifiers);
+               character.m_nview.GetZDO().Set("modifiers", serializedModifiers);
+            }
+         }
+         else
+         {
+            Modifiers = new List<MonsterModifierTypes>(Array.ConvertAll(modifiersString.Split(','),
+               str => (MonsterModifierTypes)Enum.Parse(typeof(MonsterModifierTypes), str)));
+         }
+
+         ApplyStartModifiers();
+      }
+   }
+
+   public void ChangeModifiers(List<MonsterModifierTypes> modifierTypesList, int numModifiers)
+   {
+      if (level > 1)
+      {
+         foreach (var modifier in modifierTypesList)
+         {
+            Modifiers.Add(modifier);
+            Debug.Log("Monster with name " + character.name + " has has changed modifiers. New modifier: " + modifier);
+         }
+
+         if (character.m_nview.GetZDO().IsOwner())
+         {
+            string serializedModifiers = string.Join(",", Modifiers);
+            character.m_nview.GetZDO().Set("modifiers", serializedModifiers);
+         }
+      }
+   }
+
+   public void ApplyStartModifiers()
+   {
+      if (Modifiers.Contains(MonsterModifierTypes.PersonalShield))
+         PersonalShield.AddPersonalShield(character);
+
+      if (Modifiers.Contains(MonsterModifierTypes.ShieldDome))
+      {
+         var shieldDome = character.gameObject.AddComponent<ShieldDome>();
+         shieldDome.AddShieldDome(character);
+      }
+
+      if (Modifiers.Contains(MonsterModifierTypes.StaggerImmune))
+         StaggerImmune.AddStaggerImmune(character);
+
+      if (Modifiers.Contains(MonsterModifierTypes.FastMovement))
+         FastMovement.AddFastMovement(character);
+
+      if (Modifiers.Contains(MonsterModifierTypes.DistantDetection))
+         DistantDetection.AddDistantDetection(character);
+
+      if (Modifiers.Contains(MonsterModifierTypes.Quiet))
+         Quiet.AddQuiet(character);
+
+      // Synergy: PierceImmunity + SlashImmunity + BluntImmunity + FastMovement → Armor Charge
+      // 시너지: 물리 3종 저항 + FastMovement → 철갑 돌격
+      if (Modifiers.Contains(MonsterModifierTypes.PierceImmunity) &&
+          Modifiers.Contains(MonsterModifierTypes.SlashImmunity) &&
+          Modifiers.Contains(MonsterModifierTypes.BluntImmunity) &&
+          Modifiers.Contains(MonsterModifierTypes.FastMovement))
+      {
+         Modifiers.Add(MonsterModifierTypes.ArmorCharge);
+         ArmorCharge.Apply(character);
+      }
+
+      // Synergy: FireInfused + FastAttackSpeed → fire trail particles
+      // 시너지: FireInfused + FastAttackSpeed → 화염 흔적 파티클
+      if (Modifiers.Contains(MonsterModifierTypes.FireInfused) &&
+          Modifiers.Contains(MonsterModifierTypes.FastAttackSpeed))
+      {
+         Modifiers.Add(MonsterModifierTypes.FireTrail);
+         var ft = character.gameObject.AddComponent<FireTrail>();
+         ft.Init(character);
+      }
+   }
+}

--- a/Src/Modifiers/DeathSpawns.cs
+++ b/Src/Modifiers/DeathSpawns.cs
@@ -1,0 +1,296 @@
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Jotunn;
+using Jotunn.Managers;
+using MonsterModifiers.StatusEffects;
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+public class DeathSpawns
+{
+    public static void ApplyDamageToNearbyPlayers(Vector3 position, HitData hit)
+    {
+        List<Player> nearbyPlayers = new List<Player>();
+        Player.GetPlayersInRange(position, 5f, nearbyPlayers);
+        foreach (var player in nearbyPlayers)
+        {
+            player.Damage(hit);
+        }
+    }
+    
+    [HarmonyPatch(typeof(Character), nameof(Character.OnDeath))]
+    public class DeathSpawns_Character_OnDeath_Patch
+    {
+        public static void Prefix(Character __instance)
+        {
+            if (__instance == null || __instance.IsPlayer())
+            {
+                return;
+            }
+
+            var modiferComponent = __instance.GetComponent<Custom_Components.MonsterModifier>();
+            if (modiferComponent == null)
+            {
+                return;
+            }
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.PoisonDeath))
+            {
+                float deathSpawnDamage = DamageUtils.CalculateDamage(__instance, MonsterModifiersPlugin.Cfg_PoisonDeath_DamagePercent.Value / 100f);
+                GameObject blobAoe = ZNetScene.instance.GetPrefab("blob_aoe");
+                if (blobAoe != null)
+                {
+                    Object.Instantiate(blobAoe, __instance.transform.position, __instance.transform.rotation);
+
+                    HitData poisonHit = new HitData
+                    {
+                        m_damage = { m_poison = deathSpawnDamage }
+                    };
+
+                    ApplyDamageToNearbyPlayers(__instance.transform.position, poisonHit);
+                }
+            }
+                
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.FireDeath))
+            {
+                float deathSpawnDamage = DamageUtils.CalculateDamage(__instance, MonsterModifiersPlugin.Cfg_FireDeath_DamagePercent.Value / 100f);
+                // TO-DO: I'm overwriting the vanilla values here. Make a copy somehow.
+                GameObject fireNovaAOE = ZNetScene.instance.GetPrefab("fx_fireskeleton_nova");
+
+                ParticleSystem[] listParticleSystem = fireNovaAOE.GetComponentsInChildren<ParticleSystem>();
+                foreach (var particleSystem in listParticleSystem)
+                {
+                    var main = particleSystem.main;
+                    main.startDelay = 0f;
+                }
+
+                ZSFX zsfx = fireNovaAOE.GetComponentInChildren<ZSFX>();
+                zsfx.m_delay = 0f;
+                zsfx.m_minDelay = 0f;
+                zsfx.m_maxDelay = 0f;
+
+                if (fireNovaAOE != null)
+                {
+                    
+                    Object.Instantiate(fireNovaAOE, 
+                        new Vector3(
+                            __instance.transform.position.x, __instance.transform.position.y + 1.25f, __instance.transform.position.z),
+                            __instance.transform.rotation);
+
+                    HitData fireHit = new HitData
+                    {
+                        m_damage = { m_fire = deathSpawnDamage }
+                    };
+
+                    ApplyDamageToNearbyPlayers(__instance.transform.position, fireHit);
+                }
+            }
+            
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.FrostDeath))
+            {
+                float deathSpawnDamage = DamageUtils.CalculateDamage(__instance, MonsterModifiersPlugin.Cfg_FrostDeath_DamagePercent.Value / 100f);
+                GameObject frostNovaAOE = ZNetScene.instance.GetPrefab("fx_DvergerMage_Nova_ring");
+                // TimedDestruction timedDestruction = frostNovaAOE.GetComponent<TimedDestruction>();
+                // timedDestruction.m_timeout = 2.5f;
+                
+                ParticleSystem[] listParticleSystem = frostNovaAOE.GetComponentsInChildren<ParticleSystem>();
+                foreach (var particleSystem in listParticleSystem)
+                {
+                    var main = particleSystem.main;
+                    main.startDelay = 0f;
+                }
+
+                ZSFX zsfx = frostNovaAOE.GetComponentInChildren<ZSFX>();
+                zsfx.m_delay = 0f;
+                zsfx.m_minDelay = 0f;
+                zsfx.m_maxDelay = 0f;
+                
+                    
+                if (frostNovaAOE != null)
+                {
+                    GameObject.Instantiate(frostNovaAOE, 
+                        new Vector3(
+                            __instance.transform.position.x,
+                            __instance.transform.position.y + 1f,
+                            __instance.transform.position.z
+                            ),
+                            __instance.transform.rotation);
+
+                    HitData frostHit = new HitData
+                    {
+                        m_damage = { m_frost = deathSpawnDamage }
+                    };
+
+                    ApplyDamageToNearbyPlayers(__instance.transform.position, frostHit);
+                }
+            }
+            
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.StaggerDeath))
+            {
+                GameObject customMistile = PrefabManager.Instance.GetPrefab("mistleCustomPrefab");
+
+                if (customMistile != null)
+                {
+                    GameObject.Instantiate(customMistile,
+                        new Vector3(
+                            __instance.transform.position.x,
+                            __instance.transform.position.y + 1f,
+                            __instance.transform.position.z
+                        ),
+                        __instance.transform.rotation);
+                }
+            }
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.HealDeath))
+            {
+                GameObject healNova = PrefabManager.Instance.GetPrefab("healCustomPrefab");
+                
+                float healAmount = __instance.GetMaxHealth() * (MonsterModifiersPlugin.Cfg_HealDeath_HealPercent.Value / 100f);
+                
+                if (healNova != null)
+                {
+                    GameObject.Instantiate(healNova,
+                        new Vector3(
+                            __instance.transform.position.x,
+                            __instance.transform.position.y + 1f,
+                            __instance.transform.position.z
+                        ),
+                        __instance.transform.rotation);
+                }
+
+                if (Player.m_localPlayer.IsOwner())
+                {
+                    List<Character> characters = WorldUtils.GetAllCharacter(__instance.transform.position,15f);
+                    foreach (var character in characters)
+                    {
+                        if (character == __instance || character == null)
+                        {
+                            continue;
+                        }
+                        
+                        if (character.m_nview == null || !character.m_nview.IsValid() || character.IsPlayer() || character.IsDead())
+                        {
+                            continue;
+                        }
+
+                        character.GetSEMan().AddStatusEffect("HealDeathStatusEffect".GetStableHashCode(),false,0,healAmount);
+                        // Debug.Log("Character with name: " + character.name + " was given HealDeath status effect");
+                    }
+            
+                    List<Player> nearbyPlayers = new List<Player>();
+                    Player.GetPlayersInRange(__instance.transform.position, 15f, nearbyPlayers);
+                    foreach (Character character in nearbyPlayers)
+                    {
+                        if (character == null || character.m_nview == null || !character.m_nview.IsValid())
+                        {
+                            continue;
+                        }
+
+                        character.GetSEMan().AddStatusEffect("HealDeathStatusEffect".GetStableHashCode(),true,0,healAmount);
+                        // Debug.Log("Player with name: " + character.name + " was given HealDeath status effect");
+                    }
+                }
+            }
+            
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.TarDeath))
+            {
+                GameObject tarNova = ZNetScene.instance.GetPrefab("blobtar_projectile_tarball");
+
+                if (tarNova != null)
+                {
+                    GameObject.Instantiate(tarNova,
+                        new Vector3(
+                            __instance.transform.position.x,
+                            __instance.transform.position.y + 1f,
+                            __instance.transform.position.z
+                        ),
+                        __instance.transform.rotation);
+                }
+
+                if (Player.m_localPlayer.IsOwner())
+                {
+                    List<Character> characters = WorldUtils.GetAllCharacter(__instance.transform.position,5f);
+                    foreach (var character in characters)
+                    {
+                        if (character == __instance || character == null)
+                        {
+                            continue;
+                        }
+
+                        if (character.m_nview == null || !character.m_nview.IsValid() || character.IsPlayer())
+                        {
+                            continue;
+                        }
+
+                        character.GetSEMan().AddStatusEffect("Tared".GetStableHashCode());
+                    }
+
+                    List<Player> nearbyPlayers = new List<Player>();
+                    Player.GetPlayersInRange(__instance.transform.position, 5f, nearbyPlayers);
+                    foreach (Character character in nearbyPlayers)
+                    {
+                        if (character == null || character.m_nview == null || !character.m_nview.IsValid())
+                        {
+                            continue;
+                        }
+
+                        character.GetSEMan().AddStatusEffect("Tared".GetStableHashCode());
+                    }
+                }
+            }
+
+            if (modiferComponent.Modifiers.Contains(MonsterModifierTypes.SummonDeath))
+            {
+                if (__instance.m_nview != null && __instance.m_nview.IsOwner())
+                {
+                    string prefabName = Utils.GetPrefabName(__instance.gameObject);
+                    GameObject summonPrefab = ZNetScene.instance.GetPrefab(prefabName);
+                    if (summonPrefab == null) return;
+
+                    int spawnCount = Mathf.Min(modiferComponent.Modifiers.Count + 1, 5);
+                    float parentHealth = __instance.GetMaxHealth();
+                    // 부모 속성 수 - 1 = 자식 속성 수. 0이 되면 SummonDeath 불가 → 자연 종료
+                    int childModCount = Mathf.Max(modiferComponent.Modifiers.Count - 1, 0);
+
+                    for (int i = 0; i < spawnCount; i++)
+                    {
+                        // 자식마다 개별 랜덤 롤
+                        List<MonsterModifierTypes> childMods = childModCount > 0
+                            ? ModifierUtils.RollRandomModifiers(childModCount)
+                            : new List<MonsterModifierTypes>();
+
+                        Vector3 offset = new Vector3(
+                            UnityEngine.Random.Range(-2f, 2f),
+                            0f,
+                            UnityEngine.Random.Range(-2f, 2f)
+                        );
+                        GameObject spawned = Object.Instantiate(summonPrefab,
+                            __instance.transform.position + offset,
+                            Quaternion.identity);
+
+                        spawned.transform.localScale *= MonsterModifiersPlugin.Cfg_SummonDeath_ScalePercent.Value / 100f;
+
+                        Character spawnedChar = spawned.GetComponent<Character>();
+                        if (spawnedChar == null) continue;
+
+                        int spawnLevel = childMods.Count > 0 ? childMods.Count + 1 : 1;
+                        spawnedChar.SetLevel(spawnLevel);
+
+                        ZDO? zdo = spawnedChar.m_nview?.GetZDO();
+                        if (zdo != null && zdo.IsOwner())
+                        {
+                            if (childMods.Count > 0)
+                                zdo.Set("modifiers", string.Join(",", childMods));
+                            float healthPct = MonsterModifiersPlugin.Cfg_SummonDeath_HealthPercent.Value / 100f;
+                            spawnedChar.SetMaxHealth(parentHealth * healthPct);
+                            spawnedChar.SetHealth(parentHealth * healthPct);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Src/Modifiers/Knockback.cs
+++ b/Src/Modifiers/Knockback.cs
@@ -1,0 +1,52 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+public class Knockback
+{
+    [HarmonyPatch(typeof(Character), nameof(Character.RPC_Damage))]
+    public class Knockback_Character_RPC_Damage_Patch
+    {
+        // Prefix: set m_pushForce before RPC_Damage processes it via AddPushbackForce in CustomFixedUpdate
+        public static void Prefix(Character __instance, HitData hit)
+        {
+            if (!ModifierUtils.RunRPCDamageChecks(__instance, hit))
+                return;
+
+            if (!ModifierUtils.RunHitChecks(hit, true))
+                return;
+
+            if (__instance.IsBlocking())
+                return;
+
+            Character attacker = hit.GetAttacker();
+            if (attacker == null)
+                return;
+
+            var modifierComponent = attacker.GetComponent<Custom_Components.MonsterModifier>();
+            if (modifierComponent == null)
+                return;
+
+            if (!modifierComponent.Modifiers.Contains(MonsterModifierTypes.Knockback))
+                return;
+
+            if (!__instance.IsPlayer())
+                return;
+
+            float staggerForce = MonsterModifiersPlugin.Cfg_Knockback_StaggerForce.Value;
+            float pushForce = MonsterModifiersPlugin.Cfg_Knockback_PushForce.Value;
+
+            // Trigger stagger animation via hit data
+            hit.m_pushForce = staggerForce;
+
+            // Set m_pushForce directly — Valheim's CustomFixedUpdate applies this via AddPushbackForce
+            Vector3 knockDir = hit.m_dir == Vector3.zero ? attacker.GetLookDir() : hit.m_dir;
+            knockDir.y = 0.3f;
+            knockDir.Normalize();
+
+            if (__instance.m_pushForce.magnitude < pushForce)
+                __instance.m_pushForce = knockDir * pushForce;
+        }
+    }
+}

--- a/Src/Modifiers/ShieldDome.cs
+++ b/Src/Modifiers/ShieldDome.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+using Jotunn.Entities;
+using Jotunn.Managers;
+using Jotunn.Utils;
+using MonsterModifiers.Custom_Components;
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+public class ShieldDome: MonoBehaviour
+{
+    public static CustomPrefab ShieldGenereatorBubbleCustomPrefab = null!;
+    public static EffectList.EffectData shieldDomeBubbleSFX = null!;
+    public GameObject shieldGenereatorBubble = null!;
+    public Character m_character = null!;
+    public ShieldGenerator m_shieldGenerator = null!;
+    public ShieldDomeImageEffect m_shieldDomeImageEffect = null!;
+    public ZNetView m_nview = null!;
+    
+    public static void LoadShieldDome()
+    {
+        ShieldGenereatorBubbleCustomPrefab = new CustomPrefab(ModifierAssetUtils.ashlandsAssetBundle, "ShieldDome_Bubble", true);
+        PrefabManager.Instance.AddPrefab(ShieldGenereatorBubbleCustomPrefab);
+    }
+    
+    public void AddShieldDome(Character character)
+    {
+        // Debug.Log("Monster with name " + character.m_name + " has modifier ShieldDome");
+        character.gameObject.AddComponent<ShieldDome>();
+        shieldGenereatorBubble = ZNetScene.Instantiate(ShieldGenereatorBubbleCustomPrefab.Prefab, character.transform.position,
+            character.transform.rotation);
+        
+        m_character = character;
+        
+        m_shieldGenerator = shieldGenereatorBubble.GetComponent<ShieldGenerator>();
+        m_nview = shieldGenereatorBubble.GetComponent<ZNetView>();
+
+        m_shieldGenerator.m_nview = m_nview;
+        m_shieldGenerator.m_defaultFuel = 999;
+        m_shieldGenerator.m_radius = 10;
+        m_shieldGenerator.m_maxShieldRadius = 10;
+        m_shieldGenerator.m_minShieldRadius = 10;
+        
+        m_shieldDomeImageEffect = UnityEngine.Object.FindFirstObjectByType<ShieldDomeImageEffect>();
+        
+        // Register the custom RPC for destroying the ShieldDome
+        if (m_nview != null)
+        {
+            m_nview.Register("RPC_DestroyShieldDome", new Action<long>(RPC_DestroyShieldDome));
+        }
+    }
+
+    public void Update()
+    {
+        if (m_character != null && shieldGenereatorBubble != null)
+        {
+                m_shieldGenerator.m_shieldDome.transform.position = m_character.transform.position;
+                m_shieldGenerator.m_shieldDome.transform.rotation = m_character.transform.rotation;
+         
+                m_shieldDomeImageEffect.SetShieldData(m_shieldGenerator,m_character.transform.position,10,m_shieldGenerator.m_lastFuel,m_shieldGenerator.m_lastHitTime);
+        }
+    }
+    
+    public void OnDestroy()
+    {
+        if (m_nview != null && m_nview.IsValid() && m_nview.IsOwner())
+        {
+            m_nview.InvokeRPC(ZNetView.Everybody, "RPC_DestroyShieldDome");
+        }
+    }
+    
+    private void RPC_DestroyShieldDome(long sender)
+    {
+        DestroyShieldDome();
+    }
+    
+    private void DestroyShieldDome()
+    {
+        if (m_shieldGenerator != null)
+        {
+            m_shieldDomeImageEffect.RemoveShield(m_shieldGenerator);
+        }
+
+        if (shieldGenereatorBubble != null)
+        {
+            ZNetScene.instance.Destroy(shieldGenereatorBubble);
+        }
+
+        if (m_shieldGenerator.m_shieldDome != null)
+        {
+            ZNetScene.instance.Destroy(m_shieldGenerator.m_shieldDome);
+        }
+    }
+}

--- a/Src/Visuals/BowVisuals.cs
+++ b/Src/Visuals/BowVisuals.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Jotunn.Managers;
+using MonsterModifiers.Custom_Components;
+using UnityEngine;
+
+namespace MonsterModifiers.Visuals;
+
+public class BowVisuals
+{
+    public static GameObject? GetModifierVisual(string itemName, List<MonsterModifierTypes> modifiers)
+    {
+        switch (itemName)
+        {
+            case "skeleton_bow":
+                return Visuals.BowVisuals.GetSkeletonBowVisual(modifiers);
+
+            case "draugr_bow":
+                return Visuals.BowVisuals.GetDraugrBowVisual(modifiers);
+
+            default:
+                // Debug.Log("No matching visual found for: " + itemName);
+                return null;
+        }
+    }
+
+    public static GameObject? GetSkeletonBowVisual(List<MonsterModifierTypes> modifiers)
+    {
+        if (modifiers.Contains(MonsterModifierTypes.FireInfused))
+        {
+            return PrefabManager.Instance.GetPrefab("skeletonBowCustomPrefab_Fire");
+        }
+        else if (modifiers.Contains(MonsterModifierTypes.FrostInfused))
+        {
+            return PrefabManager.Instance.GetPrefab("skeletonBowCustomPrefab_Frost");
+        }
+        else if (modifiers.Contains(MonsterModifierTypes.PoisonInfused))
+        {
+            return PrefabManager.Instance.GetPrefab("skeletonBowCustomPrefab_Poison");
+        }
+
+        return null;
+    }
+    
+    public static GameObject? GetDraugrBowVisual(List<MonsterModifierTypes> modifiers)
+    {
+        if (modifiers.Contains(MonsterModifierTypes.FireInfused))
+        {
+            return PrefabManager.Instance.GetPrefab("draugrBowCustomPrefab_Fire");
+        }
+        else if (modifiers.Contains(MonsterModifierTypes.FrostInfused))
+        {
+            return PrefabManager.Instance.GetPrefab("draugrBowCustomPrefab_Frost");
+        }
+        else if (modifiers.Contains(MonsterModifierTypes.PoisonInfused))
+        {
+            return PrefabManager.Instance.GetPrefab("draugrBowCustomPrefab_Poison");
+        }
+        
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Adds 4 new modifiers to the modifier pool.

### Knockback
Knocks back the player on hit. Uses configurable push force and stagger force via `m_pushForce` (Valheim native push system).

**New config entries (Modifier_Offense):**
- `Knockback Stagger Force` — default 500, range 0–2000
- `Knockback Push Force` — default 45, range 0–200

**Icon registration:**
- Enum entry: `Src/Utils/ModifierUtils.cs` line 44 — `Knockback,` added to `MonsterModifierTypes`
- Icon mapping: `Src/Utils/ModifierUtils.cs` line 90 — added to `GetModifierIcon()` block that returns `ModifierAssetUtils.swordIcon` (same group as FireInfused, FrostInfused, PoisonInfused, LightningInfused)

### ArmorCharge (synergy)
Activates automatically when a monster has all three immunity types + FastMovement:
`PierceImmunity + SlashImmunity + BluntImmunity + FastMovement`

Effect: +30% move speed and +50% damage on all damage types. Creates a heavily armored charging archetype.

### FireTrail (synergy)
Activates automatically when a monster has `FireInfused + FastAttackSpeed`.

Effect: leaves a burning fire particle trail on the ground as the monster moves.

### ResistanceNotification
Displays a HUD notification to the player when a damage type is resisted by the monster.

---

## Files changed

| File | Change |
|------|--------|
| `Src/Modifiers/Knockback.cs` | New modifier — push logic via `m_pushForce` |
| `Src/Modifiers/ArmorCharge.cs` | New synergy modifier |
| `Src/Modifiers/FireTrail.cs` | New synergy modifier |
| `Src/Modifiers/ResistanceNotification.cs` | New modifier |
| `Src/Utils/ModifierUtils.cs` line 44 | Added `Knockback` to `MonsterModifierTypes` enum |
| `Src/Utils/ModifierUtils.cs` line 90 | Added `Knockback` to `GetModifierIcon()` → `swordIcon` |
| `Src/Utils/SpawnCommands.cs` | `modifier [creature] [modifier]` cheat command |
| `Src/Patches/AddMonsterModifiersToCharacter.cs` | NRE guard on `UpdateCachedAnimHashes` |
| `Src/Patches/ShaderLogFilter.cs` | Suppresses shader missing-keyword log spam |

---

## Other changes

- **ShaderLogFilter**: suppresses noisy shader missing-keyword log spam from BepInEx console
- **AddMonsterModifiersToCharacter**: NRE guard on `UpdateCachedAnimHashes` — prevents crash when external mods access `Character.Animator` before initialization completes
- **SpawnCommands**: adds `modifier [creature] [modifier]` terminal cheat command for in-game testing

## Test plan

- [x] `modifier Greydwarf Knockback` — player pushed back on hit, no knockback while blocking
- [ ] Spawn monster with PierceImmunity+SlashImmunity+BluntImmunity+FastMovement — verify ArmorCharge activates (+speed, +damage)
- [ ] Spawn monster with FireInfused+FastAttackSpeed — verify fire trail appears on movement
- [ ] Hit a monster with resisted damage type — verify HUD notification appears
- [ ] Check BepInEx console — no shader spam in logs