### PR TITLE
feat: add separate modifier configs for boss monsters

### DIFF
--- a/MonsterModifiers/Src/Custom Components/MonsterModifier.cs
+++ b/MonsterModifiers/Src/Custom Components/MonsterModifier.cs
@@ -15,7 +15,12 @@ public class MonsterModifier : MonoBehaviour
    public Character character;
 
    public int level;
-   
+
+   // Set to true when attached to a boss character
+   public bool IsBossCharacter = false;
+   // Stars beyond the HUD icon slots; displayed as plain stars
+   public int OverflowStars = 0;
+
    private void Start()
    {
       character = GetComponent<Character>();
@@ -29,19 +34,53 @@ public class MonsterModifier : MonoBehaviour
          return;
       }
       
+      if (character.IsBoss())
+      {
+         if (MonsterModifiersPlugin.Configurations_Boss_Modifiers.Value == MonsterModifiersPlugin.Toggle.Off)
+            return;
+
+         IsBossCharacter = true;
+         // Stars determine modifier count, capped at boss_Modifiers_Max; remainder shown as plain stars
+         int starCount = Mathf.Max(0, level - 1);
+         int actualCount = Mathf.Min(starCount, MonsterModifiersPlugin.Configurations_Boss_MaxModifiers.Value);
+         OverflowStars = starCount - actualCount;
+
+         string bossModifiersString = character.m_nview.GetZDO().GetString("modifiers", string.Empty);
+         if (string.IsNullOrEmpty(bossModifiersString))
+         {
+            foreach (var modifier in ModifierUtils.RollRandomModifiers(actualCount, ModifierUtils.BossExcludedModifiers))
+               Modifiers.Add(modifier);
+
+            if (character.m_nview.GetZDO().IsOwner())
+               character.m_nview.GetZDO().Set("modifiers", string.Join(",", Modifiers));
+         }
+         else
+         {
+            Modifiers = new List<MonsterModifierTypes>(Array.ConvertAll(bossModifiersString.Split(','),
+               str => (MonsterModifierTypes)Enum.Parse(typeof(MonsterModifierTypes), str)));
+
+            // Recalculate overflow in case config changed
+            int reloadedActual = Mathf.Min(starCount, MonsterModifiersPlugin.Configurations_Boss_MaxModifiers.Value);
+            OverflowStars = starCount - reloadedActual;
+         }
+
+         ApplyStartModifiers();
+         return;
+      }
+
       if (level > 1)
       {
          string modifiersString = character.m_nview.GetZDO().GetString("modifiers", string.Empty);
          if (string.IsNullOrEmpty(modifiersString))
          {
             int numModifiers = Mathf.Min(level - 1, MonsterModifiersPlugin.Configurations_MaxModifiers.Value);
-            
+
             foreach (var modifier in ModifierUtils.RollRandomModifiers(numModifiers))
             {
                Modifiers.Add(modifier);
                // Debug.Log("Adding modifier: " + modifier.ToString() + " to monster with name: " + character.m_name);
             }
-            
+
             if (character.m_nview.GetZDO().IsOwner())
             {
                string serializedModifiers = string.Join(",", Modifiers);
@@ -51,7 +90,7 @@ public class MonsterModifier : MonoBehaviour
          }
          else
          {
-            Modifiers = new List<MonsterModifierTypes>(Array.ConvertAll(modifiersString.Split(','), 
+            Modifiers = new List<MonsterModifierTypes>(Array.ConvertAll(modifiersString.Split(','),
                str => (MonsterModifierTypes)Enum.Parse(typeof(MonsterModifierTypes), str)));
          }
 

--- a/MonsterModifiers/Src/Plugin.cs
+++ b/MonsterModifiers/Src/Plugin.cs
@@ -67,8 +67,12 @@ namespace MonsterModifiers
             ModifierAssetUtils.Setup();
             ModifierAssetUtils.LoadAllIcons();
             
-            Configurations_MaxModifiers = ConfigFileExtensions.BindConfig(Config, "Balance", "Max Modifiers",5,"The maximum amount of modifiers a creature can have.", true);
-            
+            Configurations_MaxModifiers = ConfigFileExtensions.BindConfig(Config, "Balance", "Monster_Modifiers_Max", 38, "Max modifier count per monster — equals star count up to this limit (0=none, 38=max)", true);
+            Configurations_Boss_Modifiers = Config.Bind("Balance", "boss_Modifiers", Toggle.On,
+                new ConfigDescription("Enable or disable modifier assignment for boss monsters."));
+            Configurations_Boss_MaxModifiers = Config.Bind("Balance", "boss_Modifiers_Max", 10,
+                new ConfigDescription("Max modifier count for boss monsters (0=none, 31=all non-death modifiers)", new AcceptableValueRange<int>(0, 31)));
+
             // ShieldDome.LoadShieldDome();
             
             CompatibilityUtils.RunCompatibiltyChecks();
@@ -79,6 +83,8 @@ namespace MonsterModifiers
         }
         
         public static ConfigEntry<int> Configurations_MaxModifiers;
+        public static ConfigEntry<Toggle> Configurations_Boss_Modifiers;
+        public static ConfigEntry<int> Configurations_Boss_MaxModifiers;
         
 
         private void OnDestroy()

--- a/MonsterModifiers/Src/Plugin.cs
+++ b/MonsterModifiers/Src/Plugin.cs
@@ -67,11 +67,9 @@ namespace MonsterModifiers
             ModifierAssetUtils.Setup();
             ModifierAssetUtils.LoadAllIcons();
             
-            Configurations_MaxModifiers = ConfigFileExtensions.BindConfig(Config, "Balance", "Monster_Modifiers_Max", 38, "Max modifier count per monster — equals star count up to this limit (0=none, 38=max)", true);
-            Configurations_Boss_Modifiers = Config.Bind("Balance", "boss_Modifiers", Toggle.On,
-                new ConfigDescription("Enable or disable modifier assignment for boss monsters."));
-            Configurations_Boss_MaxModifiers = Config.Bind("Balance", "boss_Modifiers_Max", 10,
-                new ConfigDescription("Max modifier count for boss monsters (0=none, 31=all non-death modifiers)", new AcceptableValueRange<int>(0, 31)));
+            Configurations_MaxModifiers = ConfigFileExtensions.BindConfig(Config, "Balance", "Monster_Modifiers_Max", 38, "Max modifier count per monster — equals star count up to this limit (0=none, 38=max)", true, acceptableValues: new AcceptableValueRange<int>(0, 38));
+            Configurations_Boss_Modifiers = ConfigFileExtensions.BindConfig(Config, "Balance", "boss_Modifiers", Toggle.On, "Enable or disable modifier assignment for boss monsters.", true);
+            Configurations_Boss_MaxModifiers = ConfigFileExtensions.BindConfig(Config, "Balance", "boss_Modifiers_Max", 10, "Max modifier count for boss monsters (0=none, 31=all non-death modifiers)", true, acceptableValues: new AcceptableValueRange<int>(0, 31));
 
             // ShieldDome.LoadShieldDome();
             

--- a/MonsterModifiers/Src/Utils/ModifierUtils.cs
+++ b/MonsterModifiers/Src/Utils/ModifierUtils.cs
@@ -53,6 +53,18 @@ public class ModifierUtils
 {
     public static Dictionary<MonsterModifierTypes, ModifierData> modifiers;
 
+    // Modifiers excluded from boss rolls (death explosions cause issues on bosses)
+    public static readonly HashSet<MonsterModifierTypes> BossExcludedModifiers = new HashSet<MonsterModifierTypes>
+    {
+        MonsterModifierTypes.PoisonDeath,
+        MonsterModifierTypes.FireDeath,
+        MonsterModifierTypes.FrostDeath,
+        MonsterModifierTypes.StaggerDeath,
+        MonsterModifierTypes.HealDeath,
+        MonsterModifierTypes.TarDeath,
+        MonsterModifierTypes.SummonDeath,
+    };
+
     public static Color GetModifierColor(MonsterModifierTypes modifier)
     {
         List<float> rgb = modifiers[modifier].color;
@@ -176,12 +188,17 @@ public class ModifierUtils
         return modifiers[modifier].weight;
     }
 
-    public static List<MonsterModifierTypes> RollRandomModifiers(int numModifiers)
+    public static List<MonsterModifierTypes> RollRandomModifiers(int numModifiers,
+        HashSet<MonsterModifierTypes> excluded = null)
     {
         List<MonsterModifierTypes> selectedModifiers = new List<MonsterModifierTypes>();
         Dictionary<MonsterModifierTypes, ModifierData> availableModifiers =
             new Dictionary<MonsterModifierTypes, ModifierData>(modifiers);
-        
+
+        if (excluded != null)
+            foreach (var ex in excluded)
+                availableModifiers.Remove(ex);
+
         for (int i = 0; i < numModifiers; i++)
         {
             int totalWeight = 0;


### PR DESCRIPTION
## Summary
- Rename `Max Modifiers` → `Monster_Modifiers_Max` (default 38, range 0–38) so modifier count equals star count by default
- Add `boss_Modifiers` toggle in `[Balance]` section to enable/disable modifier assignment for bosses
- Add `boss_Modifiers_Max` config in `[Balance]` section (default 10, range 0–31)
- Exclude death-spawn modifiers from boss rolls via `BossExcludedModifiers` set (PoisonDeath, FireDeath, FrostDeath, StaggerDeath, HealDeath, TarDeath, SummonDeath)
- Extend `RollRandomModifiers` with optional exclusion set parameter (backwards compatible)

## Test plan
- [ ] Spawn a star monster and verify modifier count matches star count (up to Monster_Modifiers_Max)
- [ ] Spawn a boss and verify it receives modifiers (no death-spawn modifiers assigned)
- [ ] Toggle `boss_Modifiers = Off` and verify boss receives no modifiers
- [ ] Set `boss_Modifiers_Max` to 0 and verify boss receives no modifiers