### PR TITLE
fix: add null check for item.m_dropPrefab in AddVisualsPatch

### DIFF
--- a/MonsterModifiers/Src/Patches/AddVisualsPatch.cs
+++ b/MonsterModifiers/Src/Patches/AddVisualsPatch.cs
@@ -28,13 +28,13 @@ public class AddVisualsPatch
 
             foreach (var item in humanoid.m_inventory.GetAllItems())
             {
-                if (item.m_dropPrefab.name == "skeleton_bow")
+                if (item.m_dropPrefab != null && item.m_dropPrefab.name == "skeleton_bow")
                 {
                     hasSkeletonBow = true;
                     //Debug.Log("Humanoid has skeleton bow item");
                 }
 
-                if (item.m_dropPrefab.name == "draugr_bow")
+                if (item.m_dropPrefab != null && item.m_dropPrefab.name == "draugr_bow")
                 {
                     hasDraugrBow = true;
                     // Debug.Log("Humanoid has draugr bow item");


### PR DESCRIPTION
## Summary
- Add `item.m_dropPrefab != null` guard before accessing `.name` on inventory items in `AddVisualsPatch`

## Problem
`NullReferenceException` thrown in `MonsterAI_Start_Patch.Postfix` when an inventory item has no drop prefab assigned, causing a crash in `MonsterModifier.Start`.

## Test plan
- [ ] Spawn skeleton/draugr bow creatures with elemental infusion modifiers and verify no NullReferenceException in logs