### PR TITLE
feat: add Knockback modifier

### DIFF
--- a/MonsterModifiers/Src/Config/modifierValues.yml
+++ b/MonsterModifiers/Src/Config/modifierValues.yml
@@ -129,3 +129,7 @@ Wet:
 Quiet:
   weight: 0
   color: [0.88, 0.01, 0.15, 1]  # Red
+
+Knockback:
+  weight: 2
+  color: [0.90, 0.50, 0.10, 1]  # Orange

--- a/MonsterModifiers/Src/Modifiers/Knockback.cs
+++ b/MonsterModifiers/Src/Modifiers/Knockback.cs
@@ -1,0 +1,38 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace MonsterModifiers.Modifiers;
+
+public class Knockback
+{
+    [HarmonyPatch(typeof(Character), nameof(Character.RPC_Damage))]
+    public class Knockback_Character_RPC_Damage_Patch
+    {
+        public static void Prefix(Character __instance, HitData hit)
+        {
+            if (hit == null || __instance == null) return;
+            if (hit.m_damage.GetTotalDamage() == 0) return;
+            if (!__instance.IsPlayer()) return;
+
+            var attacker = hit.GetAttacker();
+            if (attacker == null || attacker.IsPlayer()) return;
+            if (__instance.IsBlocking()) return;
+
+            var modiferComponent = attacker.GetComponent<Custom_Components.MonsterModifier>();
+            if (modiferComponent == null || !modiferComponent.Modifiers.Contains(MonsterModifierTypes.Knockback))
+                return;
+
+            hit.m_pushForce = MonsterModifiersPlugin.Cfg_Knockback_StaggerForce.Value;
+
+            Vector3 knockDir = hit.m_dir;
+            if (knockDir.sqrMagnitude < 0.01f)
+                knockDir = (__instance.transform.position - attacker.transform.position).normalized;
+            knockDir.y = 0.3f;
+            knockDir.Normalize();
+
+            float forceMagnitude = MonsterModifiersPlugin.Cfg_Knockback_PushForce.Value;
+            if (__instance.m_pushForce.magnitude < forceMagnitude)
+                __instance.m_pushForce = knockDir * forceMagnitude;
+        }
+    }
+}

--- a/MonsterModifiers/Src/Plugin.cs
+++ b/MonsterModifiers/Src/Plugin.cs
@@ -68,7 +68,12 @@ namespace MonsterModifiers
             ModifierAssetUtils.LoadAllIcons();
             
             Configurations_MaxModifiers = ConfigFileExtensions.BindConfig(Config, "Balance", "Max Modifiers",5,"The maximum amount of modifiers a creature can have.", true);
-            
+
+            Cfg_Knockback_StaggerForce = Config.Bind("Modifier_Offense", "Knockback Stagger Force", 500,
+                new ConfigDescription("Flat stagger force applied on knockback hit (default 500)", new AcceptableValueRange<int>(0, 2000)));
+            Cfg_Knockback_PushForce = Config.Bind("Modifier_Offense", "Knockback Push Force", 45,
+                new ConfigDescription("Flat push force magnitude for knockback (default 45)", new AcceptableValueRange<int>(0, 200)));
+
             // ShieldDome.LoadShieldDome();
             
             CompatibilityUtils.RunCompatibiltyChecks();
@@ -79,7 +84,10 @@ namespace MonsterModifiers
         }
         
         public static ConfigEntry<int> Configurations_MaxModifiers;
-        
+
+        // Knockback config
+        public static ConfigEntry<int> Cfg_Knockback_StaggerForce = null!;
+        public static ConfigEntry<int> Cfg_Knockback_PushForce = null!;
 
         private void OnDestroy()
         {

--- a/MonsterModifiers/Src/Utils/ModifierUtils.cs
+++ b/MonsterModifiers/Src/Utils/ModifierUtils.cs
@@ -40,7 +40,8 @@ public enum MonsterModifierTypes
     Vampiric,
     Forceful,
     Wet,
-    Quiet
+    Quiet,
+    Knockback
 }
 
 public class ModifierData
@@ -68,7 +69,8 @@ public class ModifierUtils
             modifier == MonsterModifierTypes.FrostInfused ||
             modifier == MonsterModifierTypes.PoisonInfused ||
             modifier == MonsterModifierTypes.LightningInfused ||
-            modifier == MonsterModifierTypes.RemoveStatusEffect)
+            modifier == MonsterModifierTypes.RemoveStatusEffect ||
+            modifier == MonsterModifierTypes.Knockback)
         {
             return ModifierAssetUtils.swordIcon;
         }


### PR DESCRIPTION
## Summary

Adds the Knockback modifier to the modifier pool.

Knocks back the player on hit via `m_pushForce` (Valheim native push system).
Uses Harmony Prefix so `hit.m_pushForce` is set before `RPC_Damage` processes it.
Player cannot be knocked back while blocking.

**Config entries (Modifier_Offense):**
- `Knockback Stagger Force` — default 500, range 0–2000
- `Knockback Push Force` — default 45, range 0–200

**Icon registration:**
- `Src/Utils/ModifierUtils.cs` line 44 — enum entry `Knockback`
- `Src/Utils/ModifierUtils.cs` line 73 — `GetModifierIcon()` returns `swordIcon`
  (same group as FireInfused, FrostInfused, PoisonInfused, LightningInfused)
- `Src/Utils/ModifierAssetUtils.cs` line 40 — `swordIcon` loaded from `Sword.png`
  in the `modifiericons` asset bundle

## Test plan

- [x] `modifier Greydwarf Knockback` — player pushed back on hit
- [x] Blocking while being hit — no knockback applied